### PR TITLE
Create subject CRUD with student assignment

### DIFF
--- a/api/app/Http/Controllers/StudentSubjectController.php
+++ b/api/app/Http/Controllers/StudentSubjectController.php
@@ -1,0 +1,360 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\StudentSubject;
+use App\Models\StudentSection;
+use App\Models\StudentInstitution;
+use App\Models\Subject;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Validator;
+
+class StudentSubjectController extends Controller
+{
+    /**
+     * List students assigned to a subject.
+     * Requires subject_id.
+     */
+    public function index(Request $request): JsonResponse
+    {
+        $validator = Validator::make($request->all(), [
+            'subject_id' => 'required|uuid|exists:subjects,id',
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json([
+                'success' => false,
+                'message' => 'Validation failed',
+                'errors' => $validator->errors(),
+            ], 422);
+        }
+
+        $user = $request->user();
+        $institutionId = $user->getDefaultInstitutionId();
+        if (!$institutionId) {
+            return response()->json([
+                'success' => false,
+                'message' => 'No default institution found for authenticated user',
+            ], 403);
+        }
+
+        $subject = Subject::with('classSection')
+            ->where('institution_id', $institutionId)
+            ->find($request->subject_id);
+
+        if (!$subject) {
+            return response()->json([
+                'success' => false,
+                'message' => 'Subject not found or access denied',
+            ], 404);
+        }
+
+        $assignments = StudentSubject::where('subject_id', $subject->id)
+            ->with(['student:id,lrn,first_name,middle_name,last_name,ext_name,gender,religion,birthdate,profile_picture,is_active'])
+            ->get();
+
+        return response()->json([
+            'success' => true,
+            'data' => $assignments,
+        ]);
+    }
+
+    /**
+     * Assign a single student to a subject.
+     */
+    public function store(Request $request): JsonResponse
+    {
+        $validator = Validator::make($request->all(), [
+            'student_id' => 'required|uuid|exists:students,id',
+            'subject_id' => 'required|uuid|exists:subjects,id',
+            'is_active' => 'boolean',
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json([
+                'success' => false,
+                'message' => 'Validation failed',
+                'errors' => $validator->errors(),
+            ], 422);
+        }
+
+        $user = $request->user();
+        $institutionId = $user->getDefaultInstitutionId();
+        if (!$institutionId) {
+            return response()->json([
+                'success' => false,
+                'message' => 'No default institution found for authenticated user',
+            ], 403);
+        }
+
+        $subject = Subject::with('classSection')
+            ->where('institution_id', $institutionId)
+            ->find($request->subject_id);
+
+        if (!$subject) {
+            return response()->json([
+                'success' => false,
+                'message' => 'Subject not found or access denied',
+            ], 404);
+        }
+
+        if (!$subject->is_limited_student) {
+            return response()->json([
+                'success' => false,
+                'message' => 'This subject does not allow limited student assignments',
+            ], 422);
+        }
+
+        $classSectionId = $subject->class_section_id;
+        $academicYear = optional($subject->classSection)->academic_year;
+
+        // Ensure the student is part of the subject's class section for the same academic year
+        $inSection = StudentSection::where([
+            'student_id' => $request->student_id,
+            'section_id' => $classSectionId,
+            'academic_year' => $academicYear,
+        ])->where('is_active', true)->exists();
+
+        if (!$inSection) {
+            return response()->json([
+                'success' => false,
+                'message' => 'Student is not part of the subject\'s class section for the specified academic year',
+            ], 422);
+        }
+
+        // Prevent duplicate assignment
+        $existing = StudentSubject::where([
+            'student_id' => $request->student_id,
+            'subject_id' => $subject->id,
+        ])->first();
+
+        if ($existing) {
+            return response()->json([
+                'success' => false,
+                'message' => 'Student is already assigned to this subject',
+            ], 409);
+        }
+
+        // Ensure student_institution exists
+        $hasInstitution = StudentInstitution::where('student_id', $request->student_id)
+            ->where('institution_id', $institutionId)
+            ->where('academic_year', $academicYear)
+            ->exists();
+        if (!$hasInstitution) {
+            StudentInstitution::create([
+                'student_id' => $request->student_id,
+                'institution_id' => $institutionId,
+                'is_active' => true,
+                'academic_year' => $academicYear,
+            ]);
+        }
+
+        $assignment = StudentSubject::create([
+            'student_id' => $request->student_id,
+            'subject_id' => $subject->id,
+            'academic_year' => $academicYear,
+            'is_active' => $request->is_active ?? true,
+        ]);
+
+        $assignment->load(['student:id,lrn,first_name,middle_name,last_name,ext_name,gender,religion,birthdate,profile_picture,is_active', 'subject']);
+
+        return response()->json([
+            'success' => true,
+            'message' => 'Student assigned to subject successfully',
+            'data' => $assignment,
+        ], 201);
+    }
+
+    /**
+     * Show a specific student-subject assignment.
+     */
+    public function show(string $id): JsonResponse
+    {
+        $assignment = StudentSubject::with([
+            'student:id,lrn,first_name,middle_name,last_name,ext_name,gender,religion,birthdate,profile_picture,is_active',
+            'subject:id,title,class_section_id,institution_id',
+        ])->find($id);
+
+        if (!$assignment) {
+            return response()->json([
+                'success' => false,
+                'message' => 'Student subject assignment not found',
+            ], 404);
+        }
+
+        return response()->json([
+            'success' => true,
+            'data' => $assignment,
+        ]);
+    }
+
+    /**
+     * Update assignment status (e.g., is_active).
+     */
+    public function update(Request $request, string $id): JsonResponse
+    {
+        $assignment = StudentSubject::find($id);
+        if (!$assignment) {
+            return response()->json([
+                'success' => false,
+                'message' => 'Student subject assignment not found',
+            ], 404);
+        }
+
+        $validator = Validator::make($request->all(), [
+            'is_active' => 'sometimes|boolean',
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json([
+                'success' => false,
+                'message' => 'Validation failed',
+                'errors' => $validator->errors(),
+            ], 422);
+        }
+
+        $assignment->update($request->only(['is_active']));
+
+        $assignment->load(['student:id,lrn,first_name,middle_name,last_name,ext_name,gender,religion,birthdate,profile_picture,is_active', 'subject']);
+
+        return response()->json([
+            'success' => true,
+            'message' => 'Student subject assignment updated successfully',
+            'data' => $assignment,
+        ]);
+    }
+
+    /**
+     * Delete an assignment.
+     */
+    public function destroy(string $id): JsonResponse
+    {
+        $assignment = StudentSubject::find($id);
+        if (!$assignment) {
+            return response()->json([
+                'success' => false,
+                'message' => 'Student subject assignment not found',
+            ], 404);
+        }
+
+        $assignment->delete();
+
+        return response()->json([
+            'success' => true,
+            'message' => 'Student subject assignment deleted successfully',
+        ]);
+    }
+
+    /**
+     * Bulk-assign students to a subject.
+     */
+    public function bulkAssign(Request $request): JsonResponse
+    {
+        $validator = Validator::make($request->all(), [
+            'student_ids' => 'required|array|min:1',
+            'student_ids.*' => 'required|uuid|exists:students,id',
+            'subject_id' => 'required|uuid|exists:subjects,id',
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json([
+                'success' => false,
+                'message' => 'Validation failed',
+                'errors' => $validator->errors(),
+            ], 422);
+        }
+
+        $user = $request->user();
+        $institutionId = $user->getDefaultInstitutionId();
+        if (!$institutionId) {
+            return response()->json([
+                'success' => false,
+                'message' => 'No default institution found for authenticated user',
+            ], 403);
+        }
+
+        $subject = Subject::with('classSection')
+            ->where('institution_id', $institutionId)
+            ->find($request->subject_id);
+
+        if (!$subject) {
+            return response()->json([
+                'success' => false,
+                'message' => 'Subject not found or access denied',
+            ], 404);
+        }
+
+        if (!$subject->is_limited_student) {
+            return response()->json([
+                'success' => false,
+                'message' => 'This subject does not allow limited student assignments',
+            ], 422);
+        }
+
+        $academicYear = optional($subject->classSection)->academic_year;
+        $classSectionId = $subject->class_section_id;
+        $studentIds = $request->student_ids;
+
+        // Check membership in the subject's class section for all students
+        $notInSection = collect($studentIds)->filter(function ($studentId) use ($classSectionId, $academicYear) {
+            return !StudentSection::where([
+                'student_id' => $studentId,
+                'section_id' => $classSectionId,
+                'academic_year' => $academicYear,
+            ])->where('is_active', true)->exists();
+        })->values()->all();
+
+        if (!empty($notInSection)) {
+            return response()->json([
+                'success' => false,
+                'message' => 'Some students are not part of the subject\'s class section for the specified academic year',
+                'not_in_section_student_ids' => $notInSection,
+            ], 422);
+        }
+
+        // Check for existing assignments
+        $existingAssignments = StudentSubject::where('subject_id', $subject->id)
+            ->whereIn('student_id', $studentIds)
+            ->get();
+
+        if ($existingAssignments->isNotEmpty()) {
+            $existingStudentIds = $existingAssignments->pluck('student_id')->toArray();
+            return response()->json([
+                'success' => false,
+                'message' => 'Some students are already assigned to this subject',
+                'existing_student_ids' => $existingStudentIds,
+            ], 409);
+        }
+
+        // Create missing student_institution and assignments
+        $created = [];
+        foreach ($studentIds as $studentId) {
+            $hasInstitution = StudentInstitution::where('student_id', $studentId)
+                ->where('institution_id', $institutionId)
+                ->where('academic_year', $academicYear)
+                ->exists();
+            if (!$hasInstitution) {
+                StudentInstitution::create([
+                    'student_id' => $studentId,
+                    'institution_id' => $institutionId,
+                    'is_active' => true,
+                    'academic_year' => $academicYear,
+                ]);
+            }
+
+            $created[] = StudentSubject::create([
+                'student_id' => $studentId,
+                'subject_id' => $subject->id,
+                'academic_year' => $academicYear,
+                'is_active' => true,
+            ]);
+        }
+
+        return response()->json([
+            'success' => true,
+            'message' => 'Students assigned to subject successfully',
+            'data' => $created,
+        ], 201);
+    }
+}

--- a/api/app/Models/Student.php
+++ b/api/app/Models/Student.php
@@ -50,6 +50,23 @@ class Student extends Model
     }
 
     /**
+     * Subjects the student is explicitly assigned to.
+     */
+    public function subjects()
+    {
+        return $this->belongsToMany(Subject::class, 'student_subjects', 'student_id', 'subject_id')
+            ->withTimestamps();
+    }
+
+    /**
+     * Pivot records for subject assignments.
+     */
+    public function studentSubjects()
+    {
+        return $this->hasMany(StudentSubject::class, 'student_id');
+    }
+
+    /**
      * Get the ECR item scores for the student.
      */
     public function ecrItemScores()

--- a/api/app/Models/StudentSubject.php
+++ b/api/app/Models/StudentSubject.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class StudentSubject extends Model
+{
+    use HasFactory, HasUuids;
+
+    protected $table = 'student_subjects';
+
+    protected $fillable = [
+        'student_id',
+        'subject_id',
+        'academic_year',
+        'is_active',
+    ];
+
+    protected $casts = [
+        'is_active' => 'boolean',
+    ];
+
+    public function student(): BelongsTo
+    {
+        return $this->belongsTo(Student::class);
+    }
+
+    public function subject(): BelongsTo
+    {
+        return $this->belongsTo(Subject::class);
+    }
+}

--- a/api/app/Models/Subject.php
+++ b/api/app/Models/Subject.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 
 class Subject extends Model
 {
@@ -54,6 +55,23 @@ class Subject extends Model
     public function childSubjects(): HasMany
     {
         return $this->hasMany(Subject::class, 'parent_subject_id');
+    }
+
+    /**
+     * Students explicitly assigned to this subject when is_limited_student is true.
+     */
+    public function students(): BelongsToMany
+    {
+        return $this->belongsToMany(Student::class, 'student_subjects', 'subject_id', 'student_id')
+            ->withTimestamps();
+    }
+
+    /**
+     * Pivot records for student-subject assignments.
+     */
+    public function studentSubjects(): HasMany
+    {
+        return $this->hasMany(StudentSubject::class, 'subject_id');
     }
 
     /**

--- a/api/database/migrations/2025_08_09_000000_create_student_subjects_table.php
+++ b/api/database/migrations/2025_08_09_000000_create_student_subjects_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('student_subjects', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->uuid('student_id');
+            $table->uuid('subject_id');
+            $table->string('academic_year');
+            $table->boolean('is_active')->default(true);
+            $table->timestamps();
+
+            $table->foreign('student_id')->references('id')->on('students')->onDelete('cascade');
+            $table->foreign('subject_id')->references('id')->on('subjects')->onDelete('cascade');
+            $table->unique(['student_id', 'subject_id'], 'uq_student_subject');
+            $table->index(['subject_id', 'academic_year']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('student_subjects');
+    }
+};

--- a/api/routes/api.php
+++ b/api/routes/api.php
@@ -96,6 +96,10 @@ Route::middleware('auth.token')->group(function () {
     // Subject routes
     Route::apiResource('subjects', SubjectController::class);
     Route::post('subjects/reorder', [SubjectController::class, 'reorder']);
+
+    // StudentSubject routes
+    Route::apiResource('student-subjects', App\Http\Controllers\StudentSubjectController::class);
+    Route::post('student-subjects/bulk-assign', [App\Http\Controllers\StudentSubjectController::class, 'bulkAssign']);
     // Topic routes
     Route::get('topics', [App\Http\Controllers\TopicController::class, 'index']);
     Route::post('topics', [App\Http\Controllers\TopicController::class, 'store']);

--- a/app/src/hooks/useSubjects.ts
+++ b/app/src/hooks/useSubjects.ts
@@ -131,12 +131,14 @@ export const useSubjects = (options: UseSubjectsOptions = {}) => {
     setModalSuccess(null)
 
     try {
+      let result: any
       if (editingSubject) {
-        await updateMutation.mutateAsync({ id: editingSubject.id, data: data as UpdateSubjectData })
+        result = await updateMutation.mutateAsync({ id: editingSubject.id, data: data as UpdateSubjectData })
       } else {
-        await createMutation.mutateAsync(data as CreateSubjectData)
+        result = await createMutation.mutateAsync(data as CreateSubjectData)
       }
       setIsModalOpen(false)
+      return result
     } catch {
       // Error is handled in mutation onError
     } finally {

--- a/app/src/pages/MyClassSections/ClassSectionDetail.tsx
+++ b/app/src/pages/MyClassSections/ClassSectionDetail.tsx
@@ -234,12 +234,14 @@ const ClassSectionDetail: React.FC = () => {
 
   const handleSubjectSubmit = async (data: any) => {
     try {
+      let result: any
       if (editingSubject) {
-        await updateSubjectMutation.mutateAsync({ id: editingSubject.id, data })
+        result = await updateSubjectMutation.mutateAsync({ id: editingSubject.id, data })
       } else {
-        await createSubjectMutation.mutateAsync(data)
+        result = await createSubjectMutation.mutateAsync(data)
       }
       setShowSubjectModal(false)
+      return result
     } catch (error) {
       // Error is handled in mutation onError
     }

--- a/app/src/services/studentSubjectService.ts
+++ b/app/src/services/studentSubjectService.ts
@@ -1,0 +1,31 @@
+import { api } from '../lib/api'
+import type { ApiResponse } from '../types'
+
+export interface BulkAssignStudentSubjectsPayload {
+  student_ids: string[]
+  subject_id: string
+}
+
+class StudentSubjectService {
+  async listBySubject(subjectId: string) {
+    const response = await api.get<{ success: boolean; data: any[] }>(`/student-subjects`, {
+      params: { subject_id: subjectId },
+    })
+    return response.data
+  }
+
+  async bulkAssign(payload: BulkAssignStudentSubjectsPayload) {
+    const response = await api.post<{ success: boolean; message: string; data: any[] }>(
+      `/student-subjects/bulk-assign`,
+      payload,
+    )
+    return response.data
+  }
+
+  async deleteAssignment(assignmentId: string) {
+    const response = await api.delete<ApiResponse<void>>(`/student-subjects/${assignmentId}`)
+    return response.data
+  }
+}
+
+export const studentSubjectService = new StudentSubjectService()

--- a/app/src/types/index.ts
+++ b/app/src/types/index.ts
@@ -341,17 +341,18 @@ export interface UpdateClassSectionSubjectData {
 // Student types
 export interface Student {
   id: string;
+  lrn?: string;
   first_name: string;
   middle_name?: string;
   last_name: string;
   ext_name?: string;
+  gender?: string;
+  religion?: string;
   birthdate: string;
-  gender: 'male' | 'female' | 'other';
-  religion: 'Islam' | 'Catholic' | 'Iglesia Ni Cristo' | 'Baptists' | 'Others';
-  lrn: string;
   profile_picture?: string;
-  created_at: string;
-  updated_at: string;
+  is_active: boolean;
+  created_at?: string;
+  updated_at?: string;
 }
 
 export interface CreateStudentData {


### PR DESCRIPTION
Adds API endpoints for assigning students to subjects, specifically supporting subjects marked as `is_limited_student`.

This PR implements the necessary API endpoints, models, and database structure to manage student assignments to subjects, including single and bulk assignment. It enforces business rules such as checking the `is_limited_student` flag on subjects, verifying student section membership, and preventing duplicate assignments.

---
<a href="https://cursor.com/background-agent?bcId=bc-0c3ad0f6-7ec8-4a98-8b4e-09652bd9ac3e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0c3ad0f6-7ec8-4a98-8b4e-09652bd9ac3e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

