### PR TITLE
Subject assessment builder

### DIFF
--- a/api/app/Http/Controllers/StudentAssessmentController.php
+++ b/api/app/Http/Controllers/StudentAssessmentController.php
@@ -66,6 +66,7 @@ class StudentAssessmentController extends Controller
         $items = SubjectEcrItem::with(['subjectEcr.subject'])
             ->whereIn('subject_ecr_id', $ecrIds)
             ->whereIn('type', ['quiz', 'assignment', 'exam'])
+            ->where('status', 'published')
             ->orderBy('scheduled_date')
             ->orderBy('created_at')
             ->get();
@@ -76,42 +77,57 @@ class StudentAssessmentController extends Controller
             ->orderByRaw('submitted_at IS NULL, submitted_at DESC')
             ->orderByDesc('id')
             ->get();
-        $attempts = $attemptsCollection->groupBy('subject_ecr_item_id')->map(fn ($group) => $group->first());
+        $attempts = $attemptsCollection->groupBy('subject_ecr_item_id');
 
-        $data = $items->map(function (SubjectEcrItem $item) use ($attempts, $student) {
-            $attempt = $attempts->get($item->id);
+        $data = $items->map(function (SubjectEcrItem $item) use ($attempts) {
+            $group = $attempts->get($item->id) ?? collect();
+            $attempt = $group->first();
+            $rules = $this->assessmentRules($item);
+            $submittedCount = $group->whereNotNull('submitted_at')->count();
+            $inProgress = $group->first(fn (StudentAssessmentAttempt $a) => $a->submitted_at === null);
+            $canRetake = $submittedCount < $rules['max_attempts'];
             $hasQuestions = !empty($item->content['questions'] ?? []);
             $status = 'not_started';
             $score = null;
             $maxScore = null;
             $submittedAt = null;
 
-            if ($attempt) {
-                if ($attempt->submitted_at) {
-                    $status = 'submitted';
-                    $score = $attempt->score;
-                    $maxScore = $attempt->max_score;
-                    $submittedAt = $attempt->submitted_at?->toIso8601String();
-                } else {
-                    $status = 'in_progress';
-                }
+            if ($inProgress) {
+                $status = 'in_progress';
+            } elseif ($attempt && $attempt->submitted_at && !$canRetake) {
+                $status = 'submitted';
+                $score = $attempt->score;
+                $maxScore = $attempt->max_score;
+                $submittedAt = $attempt->submitted_at?->toIso8601String();
+            } elseif ($attempt && $attempt->submitted_at) {
+                $score = $attempt->score;
+                $maxScore = $attempt->max_score;
+                $submittedAt = $attempt->submitted_at?->toIso8601String();
             }
 
             return [
                 'id' => $item->id,
                 'type' => $item->type,
+                'status' => $item->status,
                 'title' => $item->title,
                 'description' => $item->description,
                 'quarter' => $item->quarter,
                 'academic_year' => $item->academic_year,
                 'max_score' => (float) $item->score,
                 'scheduled_date' => $item->scheduled_date?->format('Y-m-d'),
+                'open_at' => $item->open_at?->toIso8601String(),
+                'close_at' => $item->close_at?->toIso8601String(),
+                'due_at' => $item->due_at?->toIso8601String(),
+                'allow_late_submission' => (bool) $item->allow_late_submission,
                 'subject_title' => $item->subjectEcr?->subject?->title ?? '',
                 'has_questions' => $hasQuestions,
                 'attempt_status' => $status,
                 'attempt_score' => $score,
                 'attempt_max_score' => $maxScore,
                 'attempt_submitted_at' => $submittedAt,
+                'attempts_used' => $submittedCount,
+                'attempts_allowed' => $rules['max_attempts'],
+                'can_retake' => $canRetake,
             ];
         });
 
@@ -130,7 +146,7 @@ class StudentAssessmentController extends Controller
         }
 
         $item = SubjectEcrItem::with(['subjectEcr.subject'])->find($id);
-        if (!$item || !in_array($item->type, ['quiz', 'assignment', 'exam'], true)) {
+        if (!$this->isSupportedAssessmentItem($item) || !$this->isPublishedForStudents($item)) {
             return response()->json(['success' => false, 'message' => 'Assessment not found.'], 404);
         }
 
@@ -144,14 +160,28 @@ class StudentAssessmentController extends Controller
             ->latest('updated_at')
             ->first();
 
+        $rules = $this->assessmentRules($item);
+        $submittedCount = StudentAssessmentAttempt::where('student_id', $student->id)
+            ->where('subject_ecr_item_id', $item->id)
+            ->whereNotNull('submitted_at')
+            ->count();
+
         $payload = [
             'id' => $item->id,
             'type' => $item->type,
+            'status' => $item->status,
             'title' => $item->title,
             'description' => $item->description,
             'quarter' => $item->quarter,
             'max_score' => (float) $item->score,
             'subject_title' => $item->subjectEcr?->subject?->title ?? '',
+            'settings' => $rules,
+            'open_at' => $item->open_at?->toIso8601String(),
+            'close_at' => $item->close_at?->toIso8601String(),
+            'due_at' => $item->due_at?->toIso8601String(),
+            'allow_late_submission' => (bool) $item->allow_late_submission,
+            'attempts_used' => $submittedCount,
+            'attempts_allowed' => $rules['max_attempts'],
         ];
 
         $questions = $item->content['questions'] ?? [];
@@ -198,13 +228,21 @@ class StudentAssessmentController extends Controller
         }
 
         $item = SubjectEcrItem::with(['subjectEcr.subject'])->find($id);
-        if (!$item || !in_array($item->type, ['quiz', 'assignment', 'exam'], true)) {
+        if (!$this->isSupportedAssessmentItem($item) || !$this->isPublishedForStudents($item)) {
             return response()->json(['success' => false, 'message' => 'Assessment not found.'], 404);
         }
 
         $subjectId = $item->subjectEcr?->subject_id;
         if (!$subjectId || !$student->subjects()->where('subjects.id', $subjectId)->exists()) {
             return response()->json(['success' => false, 'message' => 'Access denied.'], 403);
+        }
+
+        $availabilityError = $this->availabilityError($item);
+        if ($availabilityError !== null) {
+            return response()->json([
+                'success' => false,
+                'message' => $availabilityError,
+            ], 422);
         }
 
         $questions = $item->content['questions'] ?? [];
@@ -227,14 +265,15 @@ class StudentAssessmentController extends Controller
             ]);
         }
 
-        $alreadySubmitted = StudentAssessmentAttempt::where('student_id', $student->id)
+        $rules = $this->assessmentRules($item);
+        $submittedCount = StudentAssessmentAttempt::where('student_id', $student->id)
             ->where('subject_ecr_item_id', $item->id)
             ->whereNotNull('submitted_at')
-            ->exists();
-        if ($alreadySubmitted) {
+            ->count();
+        if ($submittedCount >= $rules['max_attempts']) {
             return response()->json([
                 'success' => false,
-                'message' => 'You have already submitted this assessment.',
+                'message' => 'You have reached the maximum number of attempts for this assessment.',
             ], 422);
         }
 
@@ -272,13 +311,21 @@ class StudentAssessmentController extends Controller
         ]);
 
         $item = SubjectEcrItem::find($id);
-        if (!$item || !in_array($item->type, ['quiz', 'assignment', 'exam'], true)) {
+        if (!$this->isSupportedAssessmentItem($item) || !$this->isPublishedForStudents($item)) {
             return response()->json(['success' => false, 'message' => 'Assessment not found.'], 404);
         }
 
         $subjectId = $item->subjectEcr?->subject_id;
         if (!$subjectId || !$student->subjects()->where('subjects.id', $subjectId)->exists()) {
             return response()->json(['success' => false, 'message' => 'Access denied.'], 403);
+        }
+
+        $availabilityError = $this->availabilityError($item);
+        if ($availabilityError !== null) {
+            return response()->json([
+                'success' => false,
+                'message' => $availabilityError,
+            ], 422);
         }
 
         $attempt = StudentAssessmentAttempt::where('student_id', $student->id)
@@ -347,6 +394,11 @@ class StudentAssessmentController extends Controller
             if ($type === 'fill_in_the_blanks') {
                 $blanks = $q['blanks'] ?? [];
                 $entry['num_blanks'] = count($blanks);
+            }
+            if (in_array($type, ['short_answer', 'essay'], true)) {
+                $entry['placeholder'] = $type === 'essay'
+                    ? 'Write your detailed answer here...'
+                    : 'Write your answer here...';
             }
             $out[] = $entry;
         }
@@ -434,6 +486,26 @@ class StudentAssessmentController extends Controller
             }
             return true;
         }
+        if (in_array($type, ['short_answer', 'essay'], true)) {
+            $correctRaw = $q['answer'] ?? '';
+            $correctValues = is_array($correctRaw)
+                ? $correctRaw
+                : explode('|', (string) $correctRaw);
+            $correctValues = array_values(array_filter(array_map(fn ($v) => trim((string) $v), $correctValues)));
+            if (empty($correctValues)) {
+                // No answer key means this should be manually graded.
+                return false;
+            }
+            $given = is_array($givenRaw)
+                ? trim((string) ($givenRaw[0] ?? ''))
+                : trim((string) $givenRaw);
+            foreach ($correctValues as $correct) {
+                if (strcasecmp($correct, $given) === 0) {
+                    return true;
+                }
+            }
+            return false;
+        }
         return false;
     }
 
@@ -449,17 +521,98 @@ class StudentAssessmentController extends Controller
         return $normalize($correct) === $normalize($given);
     }
 
+    private function isSupportedAssessmentItem(?SubjectEcrItem $item): bool
+    {
+        return $item !== null && in_array($item->type, ['quiz', 'assignment', 'exam'], true);
+    }
+
+    private function isPublishedForStudents(SubjectEcrItem $item): bool
+    {
+        return ($item->status ?? 'published') === 'published';
+    }
+
+    private function assessmentRules(SubjectEcrItem $item): array
+    {
+        $defaults = $this->defaultRulesForType((string) $item->type);
+        $content = is_array($item->content) ? $item->content : [];
+        $contentSettings = is_array($content['settings'] ?? null) ? $content['settings'] : [];
+        $settings = is_array($item->settings) ? $item->settings : [];
+        $merged = array_merge($defaults, $contentSettings, $settings);
+
+        return [
+            'max_attempts' => max(1, (int) ($merged['max_attempts'] ?? $defaults['max_attempts'])),
+            'time_limit_minutes' => isset($merged['time_limit_minutes']) && $merged['time_limit_minutes'] !== null && $merged['time_limit_minutes'] !== ''
+                ? max(1, (int) $merged['time_limit_minutes'])
+                : null,
+            'pass_mark' => isset($merged['pass_mark']) && $merged['pass_mark'] !== null && $merged['pass_mark'] !== ''
+                ? max(0, min(100, (float) $merged['pass_mark']))
+                : null,
+            'randomize_questions' => (bool) ($merged['randomize_questions'] ?? false),
+        ];
+    }
+
+    private function defaultRulesForType(string $type): array
+    {
+        return match ($type) {
+            'quiz' => [
+                'max_attempts' => 3,
+                'time_limit_minutes' => 30,
+                'pass_mark' => 60,
+                'randomize_questions' => false,
+            ],
+            'exam' => [
+                'max_attempts' => 1,
+                'time_limit_minutes' => 90,
+                'pass_mark' => 70,
+                'randomize_questions' => false,
+            ],
+            default => [
+                'max_attempts' => 1,
+                'time_limit_minutes' => null,
+                'pass_mark' => null,
+                'randomize_questions' => false,
+            ],
+        };
+    }
+
+    private function availabilityError(SubjectEcrItem $item): ?string
+    {
+        if (!$this->isPublishedForStudents($item)) {
+            return 'This assessment is still in draft mode.';
+        }
+
+        $now = now();
+        if ($item->open_at && $now->lt($item->open_at)) {
+            return 'This assessment is not open yet.';
+        }
+        if ($item->close_at && $now->gt($item->close_at)) {
+            return 'This assessment is already closed.';
+        }
+        if ($item->due_at && !$item->allow_late_submission && $now->gt($item->due_at)) {
+            return 'The due date for this assessment has passed.';
+        }
+
+        return null;
+    }
+
     private function buildTakePayload(SubjectEcrItem $item, StudentAssessmentAttempt $attempt): array
     {
         $questions = $item->content['questions'] ?? [];
+        $rules = $this->assessmentRules($item);
         return [
             'id' => $item->id,
             'type' => $item->type,
+            'status' => $item->status,
             'title' => $item->title,
             'description' => $item->description,
             'quarter' => $item->quarter,
             'max_score' => (float) $this->computeMaxScoreFromQuestions($questions),
             'subject_title' => $item->subjectEcr?->subject?->title ?? '',
+            'settings' => $rules,
+            'open_at' => $item->open_at?->toIso8601String(),
+            'close_at' => $item->close_at?->toIso8601String(),
+            'due_at' => $item->due_at?->toIso8601String(),
+            'allow_late_submission' => (bool) $item->allow_late_submission,
             'questions' => $this->stripAnswersFromQuestions($questions),
             'attempt_id' => $attempt->id,
             'answers' => $attempt->answers ?? [],

--- a/api/app/Http/Controllers/StudentAssessmentController.php
+++ b/api/app/Http/Controllers/StudentAssessmentController.php
@@ -88,11 +88,12 @@ class StudentAssessmentController extends Controller
 
         $data = $items->map(function (SubjectEcrItem $item) use ($attempts) {
             $group = $attempts->get($item->id) ?? collect();
-            $attempt = $group->first();
+            $latestSubmitted = $group->first(fn (StudentAssessmentAttempt $a) => $a->submitted_at !== null);
             $rules = $this->assessmentRules($item);
             $submittedCount = $group->whereNotNull('submitted_at')->count();
             $inProgress = $group->first(fn (StudentAssessmentAttempt $a) => $a->submitted_at === null);
-            $canRetake = $submittedCount < $rules['max_attempts'];
+            $attemptsAllowed = $this->effectiveMaxAttempts($item, $rules);
+            $canRetake = $submittedCount < $attemptsAllowed;
             $hasQuestions = !empty($item->content['questions'] ?? []);
             $status = 'not_started';
             $score = null;
@@ -101,15 +102,15 @@ class StudentAssessmentController extends Controller
 
             if ($inProgress) {
                 $status = 'in_progress';
-            } elseif ($attempt && $attempt->submitted_at && !$canRetake) {
+            } elseif ($latestSubmitted && !$canRetake) {
                 $status = 'submitted';
-                $score = $attempt->score;
-                $maxScore = $attempt->max_score;
-                $submittedAt = $attempt->submitted_at?->toIso8601String();
-            } elseif ($attempt && $attempt->submitted_at) {
-                $score = $attempt->score;
-                $maxScore = $attempt->max_score;
-                $submittedAt = $attempt->submitted_at?->toIso8601String();
+                $score = $latestSubmitted->score;
+                $maxScore = $latestSubmitted->max_score;
+                $submittedAt = $latestSubmitted->submitted_at?->toIso8601String();
+            } elseif ($latestSubmitted) {
+                $score = $latestSubmitted->score;
+                $maxScore = $latestSubmitted->max_score;
+                $submittedAt = $latestSubmitted->submitted_at?->toIso8601String();
             }
 
             return [
@@ -133,7 +134,7 @@ class StudentAssessmentController extends Controller
                 'attempt_max_score' => $maxScore,
                 'attempt_submitted_at' => $submittedAt,
                 'attempts_used' => $submittedCount,
-                'attempts_allowed' => $rules['max_attempts'],
+                'attempts_allowed' => $attemptsAllowed,
                 'can_retake' => $canRetake,
             ];
         });
@@ -163,16 +164,25 @@ class StudentAssessmentController extends Controller
             return response()->json(['success' => false, 'message' => 'Access denied.'], 403);
         }
 
-        $attempt = StudentAssessmentAttempt::where('student_id', $student->id)
-            ->where('subject_ecr_item_id', $item->id)
-            ->latest('updated_at')
-            ->first();
-
         $rules = $this->assessmentRules($item);
+        $attemptsAllowed = $this->effectiveMaxAttempts($item, $rules);
         $submittedCount = StudentAssessmentAttempt::where('student_id', $student->id)
             ->where('subject_ecr_item_id', $item->id)
             ->whereNotNull('submitted_at')
             ->count();
+        $canRetake = $submittedCount < $attemptsAllowed;
+
+        $inProgressAttempt = StudentAssessmentAttempt::where('student_id', $student->id)
+            ->where('subject_ecr_item_id', $item->id)
+            ->whereNull('submitted_at')
+            ->latest('updated_at')
+            ->first();
+
+        $latestSubmittedAttempt = StudentAssessmentAttempt::where('student_id', $student->id)
+            ->where('subject_ecr_item_id', $item->id)
+            ->whereNotNull('submitted_at')
+            ->latest('submitted_at')
+            ->first();
 
         $payload = [
             'id' => $item->id,
@@ -189,7 +199,7 @@ class StudentAssessmentController extends Controller
             'due_at' => $item->due_at?->toIso8601String(),
             'allow_late_submission' => (bool) $item->allow_late_submission,
             'attempts_used' => $submittedCount,
-            'attempts_allowed' => $rules['max_attempts'],
+            'attempts_allowed' => $attemptsAllowed,
         ];
 
         $questions = $item->content['questions'] ?? [];
@@ -201,24 +211,37 @@ class StudentAssessmentController extends Controller
             $payload['max_score_possible'] = (float) $item->score;
         }
 
-        if ($attempt) {
+        if ($inProgressAttempt) {
             $payload['attempt'] = [
-                'id' => $attempt->id,
-                'started_at' => $attempt->started_at?->toIso8601String(),
-                'submitted_at' => $attempt->submitted_at?->toIso8601String(),
-                'score' => $attempt->score,
-                'max_score' => $attempt->max_score,
-                'answers' => $attempt->answers,
+                'id' => $inProgressAttempt->id,
+                'started_at' => $inProgressAttempt->started_at?->toIso8601String(),
+                'submitted_at' => $inProgressAttempt->submitted_at?->toIso8601String(),
+                'score' => $inProgressAttempt->score,
+                'max_score' => $inProgressAttempt->max_score,
+                'answers' => $inProgressAttempt->answers,
             ];
-            if ($attempt->submitted_at) {
-                $payload['attempt_status'] = 'submitted';
-            } else {
-                $payload['attempt_status'] = 'in_progress';
-                $payload['answers'] = $attempt->answers ?? [];
-            }
+            $payload['attempt_status'] = 'in_progress';
+            $payload['answers'] = $inProgressAttempt->answers ?? [];
+        } elseif ($latestSubmittedAttempt && !$canRetake) {
+            $payload['attempt'] = [
+                'id' => $latestSubmittedAttempt->id,
+                'started_at' => $latestSubmittedAttempt->started_at?->toIso8601String(),
+                'submitted_at' => $latestSubmittedAttempt->submitted_at?->toIso8601String(),
+                'score' => $latestSubmittedAttempt->score,
+                'max_score' => $latestSubmittedAttempt->max_score,
+                'answers' => $latestSubmittedAttempt->answers,
+            ];
+            $payload['attempt_status'] = 'submitted';
+            $payload['answers'] = [];
         } else {
             $payload['attempt_status'] = 'not_started';
-            $payload['attempt'] = null;
+            $payload['attempt'] = $latestSubmittedAttempt ? [
+                'id' => $latestSubmittedAttempt->id,
+                'started_at' => $latestSubmittedAttempt->started_at?->toIso8601String(),
+                'submitted_at' => $latestSubmittedAttempt->submitted_at?->toIso8601String(),
+                'score' => $latestSubmittedAttempt->score,
+                'max_score' => $latestSubmittedAttempt->max_score,
+            ] : null;
             $payload['answers'] = [];
         }
 
@@ -279,10 +302,14 @@ class StudentAssessmentController extends Controller
             ->where('subject_ecr_item_id', $item->id)
             ->whereNotNull('submitted_at')
             ->count();
-        if ($submittedCount >= $rules['max_attempts']) {
+        $attemptsAllowed = $this->effectiveMaxAttempts($item, $rules);
+        if ($submittedCount >= $attemptsAllowed) {
+            $message = in_array($item->type, ['quiz', 'exam'], true)
+                ? 'You have already submitted this assessment. Answers can no longer be changed.'
+                : 'You have reached the maximum number of attempts for this assessment.';
             return response()->json([
                 'success' => false,
-                'message' => 'You have reached the maximum number of attempts for this assessment.',
+                'message' => $message,
             ], 422);
         }
 
@@ -335,6 +362,22 @@ class StudentAssessmentController extends Controller
             return response()->json([
                 'success' => false,
                 'message' => $availabilityError,
+            ], 422);
+        }
+
+        $rules = $this->assessmentRules($item);
+        $submittedCount = StudentAssessmentAttempt::where('student_id', $student->id)
+            ->where('subject_ecr_item_id', $item->id)
+            ->whereNotNull('submitted_at')
+            ->count();
+        $attemptsAllowed = $this->effectiveMaxAttempts($item, $rules);
+        if ($submittedCount >= $attemptsAllowed) {
+            $message = in_array($item->type, ['quiz', 'exam'], true)
+                ? 'You have already submitted this assessment. Answers can no longer be changed.'
+                : 'You have reached the maximum number of attempts for this assessment.';
+            return response()->json([
+                'success' => false,
+                'message' => $message,
             ], 422);
         }
 
@@ -602,6 +645,16 @@ class StudentAssessmentController extends Controller
                 : null,
             'randomize_questions' => (bool) ($merged['randomize_questions'] ?? false),
         ];
+    }
+
+    private function effectiveMaxAttempts(SubjectEcrItem $item, array $rules): int
+    {
+        // Business rule: quiz/exam answers are final after first submission.
+        if (in_array($item->type, ['quiz', 'exam'], true)) {
+            return 1;
+        }
+
+        return max(1, (int) ($rules['max_attempts'] ?? 1));
     }
 
     private function defaultRulesForType(string $type): array

--- a/api/app/Http/Controllers/StudentAssessmentController.php
+++ b/api/app/Http/Controllers/StudentAssessmentController.php
@@ -6,6 +6,9 @@ use App\Auth\StudentPortalUser;
 use App\Models\Student;
 use App\Models\StudentAssessmentAttempt;
 use App\Models\StudentEcrItemScore;
+use App\Models\StudentSection;
+use App\Models\StudentSubject;
+use App\Models\Subject;
 use App\Models\SubjectEcr;
 use App\Models\SubjectEcrItem;
 use App\Services\RunningGradeRecalcService;
@@ -53,7 +56,7 @@ class StudentAssessmentController extends Controller
             ], 403);
         }
 
-        $subjectIds = $student->subjects()->pluck('subjects.id')->toArray();
+        $subjectIds = $this->eligibleSubjectIds($student);
         if (empty($subjectIds)) {
             return response()->json(['success' => true, 'data' => []]);
         }
@@ -66,7 +69,11 @@ class StudentAssessmentController extends Controller
         $items = SubjectEcrItem::with(['subjectEcr.subject'])
             ->whereIn('subject_ecr_id', $ecrIds)
             ->whereIn('type', ['quiz', 'assignment', 'exam'])
-            ->where('status', 'published')
+            ->where(function ($q) {
+                // Backward-compatible: legacy rows may have NULL status but should behave as published.
+                $q->where('status', 'published')
+                    ->orWhereNull('status');
+            })
             ->orderBy('scheduled_date')
             ->orderBy('created_at')
             ->get();
@@ -151,7 +158,8 @@ class StudentAssessmentController extends Controller
         }
 
         $subjectId = $item->subjectEcr?->subject_id;
-        if (!$subjectId || !$student->subjects()->where('subjects.id', $subjectId)->exists()) {
+        $eligibleSubjectIds = $this->eligibleSubjectIds($student);
+        if (!$subjectId || !in_array($subjectId, $eligibleSubjectIds, true)) {
             return response()->json(['success' => false, 'message' => 'Access denied.'], 403);
         }
 
@@ -233,7 +241,8 @@ class StudentAssessmentController extends Controller
         }
 
         $subjectId = $item->subjectEcr?->subject_id;
-        if (!$subjectId || !$student->subjects()->where('subjects.id', $subjectId)->exists()) {
+        $eligibleSubjectIds = $this->eligibleSubjectIds($student);
+        if (!$subjectId || !in_array($subjectId, $eligibleSubjectIds, true)) {
             return response()->json(['success' => false, 'message' => 'Access denied.'], 403);
         }
 
@@ -316,7 +325,8 @@ class StudentAssessmentController extends Controller
         }
 
         $subjectId = $item->subjectEcr?->subject_id;
-        if (!$subjectId || !$student->subjects()->where('subjects.id', $subjectId)->exists()) {
+        $eligibleSubjectIds = $this->eligibleSubjectIds($student);
+        if (!$subjectId || !in_array($subjectId, $eligibleSubjectIds, true)) {
             return response()->json(['success' => false, 'message' => 'Access denied.'], 403);
         }
 
@@ -519,6 +529,49 @@ class StudentAssessmentController extends Controller
             return strtoupper(substr($v, 0, 1));
         };
         return $normalize($correct) === $normalize($given);
+    }
+
+    /**
+     * Resolve subjects a student can access:
+     * - non-limited subjects from active class sections
+     * - limited subjects only when explicitly assigned via student_subjects
+     * - plus explicit active assignments as fallback for migrated/legacy data.
+     */
+    private function eligibleSubjectIds(Student $student): array
+    {
+        $activeSectionIds = StudentSection::where('student_id', $student->id)
+            ->where('is_active', true)
+            ->pluck('section_id')
+            ->toArray();
+
+        $explicitAssignedSubjectIds = StudentSubject::where('student_id', $student->id)
+            ->where('is_active', true)
+            ->pluck('subject_id')
+            ->toArray();
+
+        if (empty($activeSectionIds)) {
+            return array_values(array_unique($explicitAssignedSubjectIds));
+        }
+
+        $sectionSubjectIds = Subject::whereIn('class_section_id', $activeSectionIds)
+            ->where(function ($query) use ($student) {
+                $query
+                    ->where(function ($q) {
+                        $q->where('is_limited_student', false)
+                            ->orWhereNull('is_limited_student');
+                    })
+                    ->orWhere(function ($q) use ($student) {
+                        $q->where('is_limited_student', true)
+                            ->whereHas('studentSubjects', function ($sq) use ($student) {
+                                $sq->where('student_id', $student->id)
+                                    ->where('is_active', true);
+                            });
+                    });
+            })
+            ->pluck('id')
+            ->toArray();
+
+        return array_values(array_unique(array_merge($sectionSubjectIds, $explicitAssignedSubjectIds)));
     }
 
     private function isSupportedAssessmentItem(?SubjectEcrItem $item): bool

--- a/api/app/Http/Controllers/SubjectEcrItemController.php
+++ b/api/app/Http/Controllers/SubjectEcrItemController.php
@@ -23,6 +23,7 @@ class SubjectEcrItemController extends Controller
             // Accepts subject_ecr_id as string or array (same behavior as before)
             'subject_ecr_id' => ['nullable'],
             'type' => ['nullable', 'string', Rule::in(['quiz', 'assignment', 'activity', 'project', 'exam', 'other'])],
+            'status' => ['nullable', 'string', Rule::in(['draft', 'published'])],
             'quarter' => ['nullable', 'string', Rule::in(['1', '2', '3', '4'])],
             'scheduled_date' => ['nullable', 'date_format:Y-m-d'],
             'date_from' => ['nullable', 'date_format:Y-m-d'],
@@ -76,6 +77,10 @@ class SubjectEcrItemController extends Controller
             $query->where('type', $validated['type']);
         }
 
+        if (!empty($validated['status'])) {
+            $query->where('status', $validated['status']);
+        }
+
         if (!empty($validated['quarter'])) {
             $query->where('quarter', $validated['quarter']);
         }
@@ -107,20 +112,31 @@ class SubjectEcrItemController extends Controller
             $validatedData = $request->validate([
                 'subject_ecr_id' => 'required|uuid',
                 'type' => 'nullable|string|max:255',
+                'status' => ['nullable', 'string', Rule::in(['draft', 'published'])],
                 'title' => 'required|string|max:255',
                 'description' => 'nullable|string',
                 'content' => 'nullable|array',
+                'settings' => 'nullable|array',
+                'settings.max_attempts' => 'nullable|integer|min:1|max:50',
+                'settings.time_limit_minutes' => 'nullable|integer|min:1|max:1440',
+                'settings.pass_mark' => 'nullable|numeric|min:0|max:100',
+                'settings.randomize_questions' => 'nullable|boolean',
                 'content.questions' => 'nullable|array',
-                'content.questions.*.type' => ['required_with:content.questions', 'string', Rule::in(['true_false', 'single_choice', 'multiple_choice', 'fill_in_the_blanks'])],
+                'content.questions.*.type' => ['required_with:content.questions', 'string', Rule::in(['true_false', 'single_choice', 'multiple_choice', 'fill_in_the_blanks', 'short_answer', 'essay'])],
                 'content.questions.*.question' => 'required_with:content.questions|string',
                 'content.questions.*.choices' => 'nullable|array',
                 'content.questions.*.choices.*' => 'string',
+                'content.questions.*.allow_multiple' => 'nullable|boolean',
                 'content.questions.*.answer' => 'nullable', // string or array for multiple_choice
                 'content.questions.*.blanks' => 'nullable|array', // for fill_in_the_blanks: correct answers in order
                 'content.questions.*.blanks.*' => 'string',
                 'content.questions.*.points' => 'nullable|numeric|min:0',
                 'quarter' => 'nullable|string',
                 'scheduled_date' => 'nullable|date_format:Y-m-d',
+                'open_at' => 'nullable|date',
+                'close_at' => 'nullable|date|after_or_equal:open_at',
+                'due_at' => 'nullable|date',
+                'allow_late_submission' => 'nullable|boolean',
                 'score' => 'nullable|numeric|min:0|max:999999.99',
             ]);
 
@@ -177,19 +193,32 @@ class SubjectEcrItemController extends Controller
             $validatedData = $request->validate([
                 'subject_ecr_id' => 'sometimes|required|uuid',
                 'type' => 'nullable|string|max:255',
+                'status' => ['nullable', 'string', Rule::in(['draft', 'published'])],
                 'title' => 'sometimes|required|string|max:255',
                 'description' => 'nullable|string',
                 'content' => 'nullable|array',
+                'settings' => 'nullable|array',
+                'settings.max_attempts' => 'nullable|integer|min:1|max:50',
+                'settings.time_limit_minutes' => 'nullable|integer|min:1|max:1440',
+                'settings.pass_mark' => 'nullable|numeric|min:0|max:100',
+                'settings.randomize_questions' => 'nullable|boolean',
                 'content.questions' => 'nullable|array',
-                'content.questions.*.type' => ['required_with:content.questions', 'string', Rule::in(['true_false', 'single_choice', 'multiple_choice', 'fill_in_the_blanks'])],
+                'content.questions.*.type' => ['required_with:content.questions', 'string', Rule::in(['true_false', 'single_choice', 'multiple_choice', 'fill_in_the_blanks', 'short_answer', 'essay'])],
                 'content.questions.*.question' => 'required_with:content.questions|string',
                 'content.questions.*.choices' => 'nullable|array',
                 'content.questions.*.choices.*' => 'string',
+                'content.questions.*.allow_multiple' => 'nullable|boolean',
                 'content.questions.*.answer' => 'nullable',
                 'content.questions.*.blanks' => 'nullable|array',
                 'content.questions.*.blanks.*' => 'string',
                 'content.questions.*.points' => 'nullable|numeric|min:0',
+                'quarter' => 'nullable|string',
+                'academic_year' => 'nullable|string',
                 'scheduled_date' => 'nullable|date_format:Y-m-d',
+                'open_at' => 'nullable|date',
+                'close_at' => 'nullable|date|after_or_equal:open_at',
+                'due_at' => 'nullable|date',
+                'allow_late_submission' => 'nullable|boolean',
                 'score' => 'nullable|numeric|min:0|max:999999.99',
             ]);
 

--- a/api/app/Models/SubjectEcrItem.php
+++ b/api/app/Models/SubjectEcrItem.php
@@ -19,19 +19,30 @@ class SubjectEcrItem extends Model
     protected $fillable = [
         'subject_ecr_id',
         'type',
+        'status',
         'title',
         'description',
         'content',
+        'settings',
         'quarter',
         'academic_year',
         'scheduled_date',
+        'open_at',
+        'close_at',
+        'due_at',
+        'allow_late_submission',
         'score',
     ];
 
     protected $casts = [
         'content' => 'array',
+        'settings' => 'array',
         'score' => 'decimal:2',
         'scheduled_date' => 'date:Y-m-d',
+        'open_at' => 'datetime',
+        'close_at' => 'datetime',
+        'due_at' => 'datetime',
+        'allow_late_submission' => 'boolean',
     ];
 
     /**

--- a/api/database/migrations/2026_02_28_000004_add_assessment_method_fields_to_subject_ecr_items_table.php
+++ b/api/database/migrations/2026_02_28_000004_add_assessment_method_fields_to_subject_ecr_items_table.php
@@ -1,0 +1,50 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('subject_ecr_items', function (Blueprint $table) {
+            $table->string('status')->default('published')->after('type');
+            $table->json('settings')->nullable()->after('content');
+            $table->dateTime('open_at')->nullable()->after('scheduled_date');
+            $table->dateTime('close_at')->nullable()->after('open_at');
+            $table->dateTime('due_at')->nullable()->after('close_at');
+            $table->boolean('allow_late_submission')->default(false)->after('due_at');
+
+            $table->index(['type', 'status']);
+            $table->index('open_at');
+            $table->index('close_at');
+            $table->index('due_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('subject_ecr_items', function (Blueprint $table) {
+            $table->dropIndex(['type', 'status']);
+            $table->dropIndex(['open_at']);
+            $table->dropIndex(['close_at']);
+            $table->dropIndex(['due_at']);
+
+            $table->dropColumn([
+                'status',
+                'settings',
+                'open_at',
+                'close_at',
+                'due_at',
+                'allow_late_submission',
+            ]);
+        });
+    }
+};

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -4,6 +4,7 @@ import { QueryProvider } from './providers/QueryProvider';
 import { AuthProvider } from './providers/AuthProvider';
 import PublicLayout from './components/layouts/PublicLayout';
 import PrivateLayout from './components/layouts/PrivateLayout';
+import StudentOnlyRoute from './components/StudentOnlyRoute';
 import Dashboard from './pages/Dashboard';
 import Users from './pages/Users';
 import Institutions from './pages/Institutions';
@@ -68,8 +69,22 @@ function App() {
               <Route path="my-class-sections/:id" element={<ClassSectionDetail />} />
               <Route path="assigned-subjects" element={<AssignedSubjects />} />
               <Route path="assigned-subjects/:id" element={<SubjectDetail />} />
-              <Route path="my-assessments" element={<MyAssessments />} />
-              <Route path="my-assessments/:id/take" element={<TakeAssessment />} />
+              <Route
+                path="my-assessments"
+                element={(
+                  <StudentOnlyRoute>
+                    <MyAssessments />
+                  </StudentOnlyRoute>
+                )}
+              />
+              <Route
+                path="my-assessments/:id/take"
+                element={(
+                  <StudentOnlyRoute>
+                    <TakeAssessment />
+                  </StudentOnlyRoute>
+                )}
+              />
               <Route path="my-personal-info" element={<MyPersonalInfo />} />
               <Route path="my-subjects" element={<MySubjects />} />
               <Route path="teacher-attendance" element={<TeacherAttendance />} />

--- a/app/src/components/StudentOnlyRoute.tsx
+++ b/app/src/components/StudentOnlyRoute.tsx
@@ -1,0 +1,31 @@
+import React from 'react'
+import { Navigate } from 'react-router-dom'
+import { useAuth } from '@/hooks/useAuth'
+
+interface StudentOnlyRouteProps {
+  children: React.ReactElement
+}
+
+const StudentOnlyRoute: React.FC<StudentOnlyRouteProps> = ({ children }) => {
+  const { isLoading, isAuthenticated, user } = useAuth()
+
+  if (isLoading) {
+    return (
+      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+        <div className="animate-spin rounded-full h-10 w-10 border-b-2 border-indigo-600" />
+      </div>
+    )
+  }
+
+  if (!isAuthenticated) {
+    return <Navigate to="/login" replace />
+  }
+
+  if (user?.role?.slug !== 'student') {
+    return <Navigate to="/dashboard" replace />
+  }
+
+  return children
+}
+
+export default StudentOnlyRoute

--- a/app/src/components/sidebar/Sidebar.tsx
+++ b/app/src/components/sidebar/Sidebar.tsx
@@ -73,13 +73,13 @@ const menuItems: MenuItem[] = [
     path: '/assigned-subjects',
     allowedRoles: ['subject-teacher', 'principal', 'institution-administrator'],
   },
-  // Temporarily hidden:
-  // {
-  //   id: 'my-assessments',
-  //   label: 'My Assessments',
-  //   icon: <ClipboardList className="w-5 h-5" />,
-  //   path: '/my-assessments',
-  // },
+  {
+    id: 'my-assessments',
+    label: 'My Assessments',
+    icon: <FileText className="w-5 h-5" />,
+    path: '/my-assessments',
+    allowedRoles: ['student'],
+  },
   {
     id: 'users',
     label: 'Users',

--- a/app/src/pages/AssignedSubjects/SubjectDetail.tsx
+++ b/app/src/pages/AssignedSubjects/SubjectDetail.tsx
@@ -24,7 +24,7 @@ import SummativeAssessmentTab from './components/SummativeAssessmentTab'
 import { AssessmentBuilderTab } from './components/AssessmentBuilderTab'
 import type { Subject, Student, ClassSection } from '../../types'
 
-type TabType = 'class-record' | 'topics' | 'calendar' | 'student-scores' | 'summative-assessment' | 'assessment-builder' | 'ai-planner' | 'lesson-plan-calendar'
+type TabType = 'class-record' | 'topics' | 'calendar' | 'student-scores' | 'summative-assessment' | 'assessment-methods' | 'ai-planner' | 'lesson-plan-calendar'
 
 // Extend types locally to allow students array on class_section
 interface ClassSectionWithStudents extends ClassSection {
@@ -97,12 +97,11 @@ const SubjectDetail: React.FC = () => {
       label: 'Components of Summative Assessment',
       icon: ListBulletIcon,
     },
-    // Temporarily hidden:
-    // {
-    //   id: 'assessment-builder' as TabType,
-    //   label: 'Quiz / Assignment / Exam Builder',
-    //   icon: DocumentTextIcon,
-    // },
+    {
+      id: 'assessment-methods' as TabType,
+      label: 'Assessment Methods',
+      icon: DocumentTextIcon,
+    },
     // {
     //   id: 'topics' as TabType,
     //   label: 'Topics',
@@ -225,7 +224,7 @@ const SubjectDetail: React.FC = () => {
             />
           )}
           {activeTab === 'summative-assessment' && <SummativeAssessmentTab subjectId={subject.id} />}
-          {activeTab === 'assessment-builder' && <AssessmentBuilderTab subjectId={subject.id} />}
+          {activeTab === 'assessment-methods' && <AssessmentBuilderTab subjectId={subject.id} />}
           {activeTab === 'topics' && <TopicsTab subjectId={subject.id} />}
           {activeTab === 'ai-planner' && <AiPlannerTab subjectId={subject.id} />}
           {activeTab === 'lesson-plan-calendar' && <LessonPlanCalendarTab subjectId={subject.id} />}

--- a/app/src/pages/AssignedSubjects/components/AssessmentBuilderTab.tsx
+++ b/app/src/pages/AssignedSubjects/components/AssessmentBuilderTab.tsx
@@ -1,592 +1,1268 @@
-import React, { useState } from 'react';
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { PlusIcon, PencilIcon, TrashIcon } from '@heroicons/react/24/outline';
-import { subjectEcrService } from '@/services/subjectEcrService';
-import { subjectEcrItemService, type SubjectEcrItem } from '@/services/subjectEcrItemService';
-import { Button } from '@/components/button';
-import { Input } from '@/components/input';
-import { Badge } from '@/components/badge';
-
-type AssessmentType = 'quiz' | 'assignment' | 'exam';
+import React, { useMemo, useState } from 'react'
+import clsx from 'clsx'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import {
+  PlusIcon,
+  PencilIcon,
+  TrashIcon,
+  XMarkIcon,
+  Bars3Icon,
+  DocumentTextIcon,
+  CalendarDaysIcon,
+  ClockIcon,
+} from '@heroicons/react/24/outline'
+import {
+  DndContext,
+  DragOverlay,
+  PointerSensor,
+  closestCenter,
+  useDraggable,
+  useDroppable,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+  type DragStartEvent,
+} from '@dnd-kit/core'
+import {
+  SortableContext,
+  arrayMove,
+  useSortable,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable'
+import { CSS } from '@dnd-kit/utilities'
+import { nanoid } from 'nanoid'
+import { subjectEcrService } from '@/services/subjectEcrService'
+import {
+  DEFAULT_RULES_BY_TYPE,
+  assessmentMethodService,
+  type AssessmentMethod,
+  type AssessmentMethodInput,
+  type AssessmentMethodQuestion,
+  type AssessmentMethodRules,
+  type AssessmentMethodType,
+  type AssessmentPublishStatus,
+  type AssessmentQuestionType,
+} from '@/services/assessmentMethodService'
+import { Button } from '@/components/button'
+import { Input } from '@/components/input'
+import { Badge } from '@/components/badge'
+import { Switch } from '@/components/switch'
 
 interface AssessmentBuilderTabProps {
-  subjectId: string;
+  subjectId: string
 }
 
-type QuestionType = 'true_false' | 'single_choice' | 'multiple_choice' | 'fill_in_the_blanks';
-
-interface QuestionForm {
-  type: QuestionType;
-  question: string;
-  choices: string[];
-  answer: string;
-  answerMultiple: string[]; // for multiple_choice (e.g. ['A','B'])
-  blanks: string[]; // for fill_in_the_blanks (correct answers in order)
-  points: number;
+interface BuilderDraft {
+  id?: string
+  subjectEcrId: string
+  type: AssessmentMethodType
+  status: AssessmentPublishStatus
+  title: string
+  description: string
+  quarter: string
+  scheduledDate: string
+  openAt: string
+  closeAt: string
+  dueAt: string
+  allowLateSubmission: boolean
+  rules: AssessmentMethodRules
+  questions: AssessmentMethodQuestion[]
 }
 
-const QUESTION_TYPE_LABELS: Record<QuestionType, string> = {
+const CANVAS_DROP_ID = 'assessment-method-question-canvas'
+const PALETTE_PREFIX = 'assessment-palette::'
+
+const TYPE_OPTIONS: Array<{ id: AssessmentMethodType; label: string }> = [
+  { id: 'quiz', label: 'Quiz' },
+  { id: 'assignment', label: 'Assignment' },
+  { id: 'exam', label: 'Exam' },
+]
+
+const QUESTION_TYPE_OPTIONS: Array<{
+  type: AssessmentQuestionType
+  label: string
+  hint: string
+}> = [
+  { type: 'single_choice', label: 'Multiple Choice', hint: 'One correct option' },
+  { type: 'multiple_choice', label: 'Multiple Response', hint: 'Many correct options' },
+  { type: 'true_false', label: 'True / False', hint: 'Binary answer' },
+  { type: 'fill_in_the_blanks', label: 'Fill in the Blanks', hint: 'Ordered blank answers' },
+  { type: 'short_answer', label: 'Short Answer', hint: 'Short text response' },
+  { type: 'essay', label: 'Essay', hint: 'Long-form response' },
+]
+
+const QUESTION_TYPE_LABELS: Record<AssessmentQuestionType, string> = {
+  single_choice: 'Multiple Choice',
+  multiple_choice: 'Multiple Response',
   true_false: 'True / False',
-  single_choice: 'Single Choice',
-  multiple_choice: 'Multiple Choice',
-  fill_in_the_blanks: 'Fill In The Blanks',
-};
+  fill_in_the_blanks: 'Fill in the Blanks',
+  short_answer: 'Short Answer',
+  essay: 'Essay',
+}
 
-const DEFAULT_QUESTION: QuestionForm = {
-  type: 'single_choice',
-  question: '',
-  choices: ['A. ', 'B. ', 'C. ', 'D. '],
-  answer: 'A',
-  answerMultiple: [],
-  blanks: [''],
-  points: 1,
-};
+const toDateTimeLocal = (value: string | null | undefined): string => {
+  if (!value) return ''
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return ''
+  const pad = (num: number) => `${num}`.padStart(2, '0')
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}`
+}
+
+const formatDateTime = (value: string | null | undefined): string => {
+  if (!value) return 'Not set'
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return value
+  return date.toLocaleString()
+}
+
+const choiceLetter = (index: number) => String.fromCharCode(65 + index)
+
+const makeQuestion = (type: AssessmentQuestionType): AssessmentMethodQuestion => {
+  if (type === 'true_false') {
+    return {
+      id: nanoid(),
+      type,
+      prompt: '',
+      points: 1,
+      choices: ['True', 'False'],
+      correctAnswers: ['True'],
+      blanks: [],
+      sampleAnswer: '',
+    }
+  }
+  if (type === 'fill_in_the_blanks') {
+    return {
+      id: nanoid(),
+      type,
+      prompt: '',
+      points: 1,
+      choices: [],
+      correctAnswers: [],
+      blanks: [''],
+      sampleAnswer: '',
+    }
+  }
+  if (type === 'short_answer' || type === 'essay') {
+    return {
+      id: nanoid(),
+      type,
+      prompt: '',
+      points: 1,
+      choices: [],
+      correctAnswers: [],
+      blanks: [],
+      sampleAnswer: '',
+    }
+  }
+  return {
+    id: nanoid(),
+    type,
+    prompt: '',
+    points: 1,
+    choices: ['', ''],
+    correctAnswers: ['A'],
+    blanks: [],
+    sampleAnswer: '',
+  }
+}
+
+const draftFromAssessment = (assessment: AssessmentMethod): BuilderDraft => ({
+  id: assessment.id,
+  subjectEcrId: assessment.subjectEcrId,
+  type: assessment.type,
+  status: assessment.status,
+  title: assessment.title,
+  description: assessment.description,
+  quarter: assessment.quarter,
+  scheduledDate: assessment.scheduledDate ?? '',
+  openAt: toDateTimeLocal(assessment.openAt),
+  closeAt: toDateTimeLocal(assessment.closeAt),
+  dueAt: toDateTimeLocal(assessment.dueAt),
+  allowLateSubmission: assessment.allowLateSubmission,
+  rules: assessment.rules,
+  questions: assessment.questions.map((question) => ({
+    ...question,
+    id: question.id || nanoid(),
+    choices:
+      question.type === 'single_choice' || question.type === 'multiple_choice'
+        ? question.choices.length > 0
+          ? question.choices
+          : ['', '']
+        : question.choices,
+    blanks: question.type === 'fill_in_the_blanks' && question.blanks.length === 0 ? [''] : question.blanks,
+  })),
+})
+
+const newDraft = (type: AssessmentMethodType, subjectEcrId: string): BuilderDraft => ({
+  subjectEcrId,
+  type,
+  status: 'draft',
+  title: '',
+  description: '',
+  quarter: '1',
+  scheduledDate: '',
+  openAt: '',
+  closeAt: '',
+  dueAt: '',
+  allowLateSubmission: false,
+  rules: { ...DEFAULT_RULES_BY_TYPE[type] },
+  questions: [],
+})
+
+const paletteCardId = (type: AssessmentQuestionType) => `${PALETTE_PREFIX}${type}`
+
+const PaletteCard: React.FC<{
+  type: AssessmentQuestionType
+  label: string
+  hint: string
+}> = ({ type, label, hint }) => {
+  const { attributes, listeners, setNodeRef, transform, isDragging } = useDraggable({
+    id: paletteCardId(type),
+  })
+
+  return (
+    <button
+      ref={setNodeRef}
+      type="button"
+      className={clsx(
+        'w-full rounded-xl border border-gray-200 bg-white px-3 py-3 text-left transition hover:border-indigo-300 hover:bg-indigo-50',
+        isDragging && 'opacity-50'
+      )}
+      style={{ transform: CSS.Translate.toString(transform) }}
+      {...attributes}
+      {...listeners}
+    >
+      <p className="text-sm font-semibold text-gray-900">{label}</p>
+      <p className="mt-1 text-xs text-gray-500">{hint}</p>
+    </button>
+  )
+}
+
+interface SortableQuestionCardProps {
+  question: AssessmentMethodQuestion
+  index: number
+  onTypeChange: (id: string, type: AssessmentQuestionType) => void
+  onPromptChange: (id: string, prompt: string) => void
+  onPointsChange: (id: string, points: number) => void
+  onRemove: (id: string) => void
+  onChoiceChange: (id: string, index: number, value: string) => void
+  onAddChoice: (id: string) => void
+  onRemoveChoice: (id: string, index: number) => void
+  onToggleCorrectChoice: (id: string, letter: string, allowMultiple: boolean) => void
+  onTrueFalseChange: (id: string, value: 'True' | 'False') => void
+  onBlankChange: (id: string, index: number, value: string) => void
+  onAddBlank: (id: string) => void
+  onRemoveBlank: (id: string, index: number) => void
+  onSampleAnswerChange: (id: string, value: string) => void
+}
+
+const SortableQuestionCard: React.FC<SortableQuestionCardProps> = ({
+  question,
+  index,
+  onTypeChange,
+  onPromptChange,
+  onPointsChange,
+  onRemove,
+  onChoiceChange,
+  onAddChoice,
+  onRemoveChoice,
+  onToggleCorrectChoice,
+  onTrueFalseChange,
+  onBlankChange,
+  onAddBlank,
+  onRemoveBlank,
+  onSampleAnswerChange,
+}) => {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: question.id,
+  })
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={{
+        transform: CSS.Transform.toString(transform),
+        transition,
+      }}
+      className={clsx(
+        'rounded-xl border border-gray-200 bg-white p-4 shadow-sm',
+        isDragging && 'opacity-60'
+      )}
+    >
+      <div className="mb-3 flex flex-wrap items-start justify-between gap-3">
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            className="cursor-grab rounded-md border border-gray-200 p-1 text-gray-500 active:cursor-grabbing"
+            {...attributes}
+            {...listeners}
+            title="Drag to reorder"
+          >
+            <Bars3Icon className="h-4 w-4" />
+          </button>
+          <span className="text-sm font-semibold text-gray-900">Question {index + 1}</span>
+          <Badge color="indigo">{QUESTION_TYPE_LABELS[question.type]}</Badge>
+        </div>
+        <div className="flex items-center gap-2">
+          <div className="w-40">
+            <label className="mb-1 block text-xs font-medium text-gray-600">Type</label>
+            <select
+              className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm"
+              value={question.type}
+              onChange={(event) => onTypeChange(question.id, event.target.value as AssessmentQuestionType)}
+            >
+              {QUESTION_TYPE_OPTIONS.map((option) => (
+                <option key={option.type} value={option.type}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="w-24">
+            <label className="mb-1 block text-xs font-medium text-gray-600">Points</label>
+            <Input
+              type="number"
+              min={0}
+              step={0.5}
+              value={question.points}
+              onChange={(event) => onPointsChange(question.id, Number(event.target.value) || 0)}
+            />
+          </div>
+          <Button type="button" variant="ghost" color="danger" onClick={() => onRemove(question.id)}>
+            Remove
+          </Button>
+        </div>
+      </div>
+
+      <div className="mb-3">
+        <label className="mb-1 block text-xs font-medium text-gray-600">Question prompt</label>
+        <textarea
+          className="min-h-20 w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+          value={question.prompt}
+          onChange={(event) => onPromptChange(question.id, event.target.value)}
+          placeholder="Type your question..."
+        />
+      </div>
+
+      {(question.type === 'single_choice' || question.type === 'multiple_choice') && (
+        <div className="space-y-2">
+          <div className="flex items-center justify-between">
+            <label className="block text-xs font-medium text-gray-600">Choices</label>
+            <Button type="button" variant="outline" size="sm" onClick={() => onAddChoice(question.id)}>
+              + Choice
+            </Button>
+          </div>
+          {question.choices.map((choice, choiceIndex) => {
+            const letter = choiceLetter(choiceIndex)
+            const checked = question.correctAnswers.includes(letter)
+            return (
+              <div key={choiceIndex} className="flex items-center gap-2">
+                <button
+                  type="button"
+                  className={clsx(
+                    'h-6 w-6 rounded-full border text-xs font-semibold',
+                    checked
+                      ? 'border-indigo-500 bg-indigo-600 text-white'
+                      : 'border-gray-300 bg-white text-gray-700'
+                  )}
+                  onClick={() => onToggleCorrectChoice(question.id, letter, question.type === 'multiple_choice')}
+                  title="Mark as correct"
+                >
+                  {letter}
+                </button>
+                <Input
+                  value={choice}
+                  onChange={(event) => onChoiceChange(question.id, choiceIndex, event.target.value)}
+                  placeholder={`Option ${letter}`}
+                />
+                {question.choices.length > 2 && (
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    color="danger"
+                    size="sm"
+                    onClick={() => onRemoveChoice(question.id, choiceIndex)}
+                  >
+                    Remove
+                  </Button>
+                )}
+              </div>
+            )
+          })}
+          <p className="text-xs text-gray-500">
+            {question.type === 'multiple_choice'
+              ? 'Select all correct options.'
+              : 'Select the single correct option.'}
+          </p>
+        </div>
+      )}
+
+      {question.type === 'true_false' && (
+        <div>
+          <label className="mb-1 block text-xs font-medium text-gray-600">Correct answer</label>
+          <div className="flex gap-2">
+            {(['True', 'False'] as const).map((value) => (
+              <button
+                key={value}
+                type="button"
+                onClick={() => onTrueFalseChange(question.id, value)}
+                className={clsx(
+                  'rounded-lg border px-3 py-2 text-sm font-medium',
+                  question.correctAnswers[0] === value
+                    ? 'border-indigo-500 bg-indigo-50 text-indigo-700'
+                    : 'border-gray-300 bg-white text-gray-700'
+                )}
+              >
+                {value}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {question.type === 'fill_in_the_blanks' && (
+        <div className="space-y-2">
+          <div className="flex items-center justify-between">
+            <label className="block text-xs font-medium text-gray-600">Correct blank answers (in order)</label>
+            <Button type="button" variant="outline" size="sm" onClick={() => onAddBlank(question.id)}>
+              + Blank
+            </Button>
+          </div>
+          {question.blanks.map((blank, blankIndex) => (
+            <div key={blankIndex} className="flex items-center gap-2">
+              <Input
+                value={blank}
+                onChange={(event) => onBlankChange(question.id, blankIndex, event.target.value)}
+                placeholder={`Blank ${blankIndex + 1}`}
+              />
+              {question.blanks.length > 1 && (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  color="danger"
+                  size="sm"
+                  onClick={() => onRemoveBlank(question.id, blankIndex)}
+                >
+                  Remove
+                </Button>
+              )}
+            </div>
+          ))}
+          <p className="text-xs text-gray-500">
+            Use a pipe to allow alternatives (example: Manila | Manila City).
+          </p>
+        </div>
+      )}
+
+      {(question.type === 'short_answer' || question.type === 'essay') && (
+        <div>
+          <label className="mb-1 block text-xs font-medium text-gray-600">
+            {question.type === 'essay' ? 'Suggested rubric answer (optional)' : 'Expected answer (optional)'}
+          </label>
+          <textarea
+            className="min-h-20 w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+            value={question.sampleAnswer}
+            onChange={(event) => onSampleAnswerChange(question.id, event.target.value)}
+            placeholder="Optional answer key for auto-checking"
+          />
+        </div>
+      )}
+    </div>
+  )
+}
 
 export const AssessmentBuilderTab: React.FC<AssessmentBuilderTabProps> = ({ subjectId }) => {
-  const queryClient = useQueryClient();
-  const [builderType, setBuilderType] = useState<AssessmentType>('quiz');
-  const [modalOpen, setModalOpen] = useState(false);
-  const [editingItem, setEditingItem] = useState<SubjectEcrItem | null>(null);
-  const [form, setForm] = useState({
-    title: '',
-    description: '',
-    score: 10,
-    quarter: '1',
-    questions: [] as QuestionForm[],
-  });
+  const queryClient = useQueryClient()
+  const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 6 } }))
+
+  const [activeType, setActiveType] = useState<AssessmentMethodType>('quiz')
+  const [builderOpen, setBuilderOpen] = useState(false)
+  const [draft, setDraft] = useState<BuilderDraft | null>(null)
+  const [activeDragId, setActiveDragId] = useState<string | null>(null)
 
   const { data: ecrRes } = useQuery({
     queryKey: ['subjectEcrs', subjectId],
     queryFn: () => subjectEcrService.getBySubject(subjectId),
     enabled: !!subjectId,
-  });
-  const ecrs = (ecrRes?.data ?? []) as { id: string; title: string }[];
-  const firstEcrId = ecrs[0]?.id;
+  })
 
-  const { data: itemsRes, isLoading } = useQuery({
-    queryKey: ['subjectEcrItems', subjectId, builderType],
-    queryFn: () =>
-      subjectEcrItemService.listBySubject({
-        subject_id: subjectId,
-        type: builderType,
-      }),
+  const ecrs = (ecrRes?.data ?? []) as { id: string; title: string }[]
+  const firstEcrId = ecrs[0]?.id
+
+  const { data: methods = [], isLoading } = useQuery({
+    queryKey: ['assessment-methods', subjectId, activeType],
+    queryFn: () => assessmentMethodService.listBySubject(subjectId, activeType),
     enabled: !!subjectId,
-  });
-  const items = (itemsRes?.data ?? []) as SubjectEcrItem[];
+  })
 
-  const createMutation = useMutation({
-    mutationFn: (data: Omit<SubjectEcrItem, 'id'>) => subjectEcrItemService.create(data),
+  const saveCreateMutation = useMutation({
+    mutationFn: (payload: AssessmentMethodInput) => assessmentMethodService.create(payload),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['subjectEcrItems'] });
-      closeModal();
+      queryClient.invalidateQueries({ queryKey: ['assessment-methods', subjectId] })
+      setBuilderOpen(false)
+      setDraft(null)
     },
-  });
-  const updateMutation = useMutation({
-    mutationFn: ({ id, data }: { id: string; data: Partial<SubjectEcrItem> }) =>
-      subjectEcrItemService.update(id, data),
+  })
+
+  const saveUpdateMutation = useMutation({
+    mutationFn: ({ id, payload }: { id: string; payload: AssessmentMethodInput }) =>
+      assessmentMethodService.update(id, payload),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['subjectEcrItems'] });
-      closeModal();
+      queryClient.invalidateQueries({ queryKey: ['assessment-methods', subjectId] })
+      setBuilderOpen(false)
+      setDraft(null)
     },
-  });
+  })
+
   const deleteMutation = useMutation({
-    mutationFn: (id: string) => subjectEcrItemService.delete(id),
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['subjectEcrItems'] }),
-  });
+    mutationFn: (id: string) => assessmentMethodService.remove(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['assessment-methods', subjectId] })
+    },
+  })
 
-  const closeModal = () => {
-    setModalOpen(false);
-    setEditingItem(null);
-    setForm({
-      title: '',
-      description: '',
-      score: 10,
-      quarter: '1',
-      questions: [],
-    });
-  };
+  const totalPoints = useMemo(
+    () => draft?.questions.reduce((sum, question) => sum + (Number(question.points) || 0), 0) ?? 0,
+    [draft]
+  )
 
-  const openCreate = () => {
-    setEditingItem(null);
-    setForm({
-      title: '',
-      description: '',
-      score: builderType === 'exam' ? 50 : builderType === 'quiz' ? 10 : 20,
-      quarter: '1',
-      questions: [{ ...DEFAULT_QUESTION }],
-    });
-    setModalOpen(true);
-  };
+  const validationErrors = useMemo(() => {
+    if (!draft) return []
+    const errors: string[] = []
 
-  const openEdit = (item: SubjectEcrItem) => {
-    setEditingItem(item);
-    const questions = (item.content?.questions ?? []).map((q: any) => {
-      const type = (q.type ?? 'single_choice') as QuestionType;
-      const answerRaw = q.answer;
-      const answerSingle = Array.isArray(answerRaw)
-        ? (answerRaw[0] ?? 'A').toString().trim().charAt(0).toUpperCase() || 'A'
-        : (answerRaw ?? 'A').toString().trim().charAt(0).toUpperCase() || 'A';
-      const answerMultiple = Array.isArray(answerRaw)
-        ? answerRaw.map((a: string) => (a ?? '').toString().trim().charAt(0).toUpperCase() || '')
-        : (typeof answerRaw === 'string' && answerRaw.includes(','))
-          ? answerRaw.split(',').map((a: string) => a.trim().charAt(0).toUpperCase() || '')
-          : [];
-      return {
-        type,
-        question: q.question ?? '',
-        choices: type === 'true_false' ? ['True', 'False'] : (Array.isArray(q.choices) ? q.choices : ['A. ', 'B. ', 'C. ', 'D. ']),
-        answer: type === 'true_false' ? (answerSingle === 'T' ? 'True' : 'False') : answerSingle,
-        answerMultiple: answerMultiple.length ? answerMultiple : [],
-        blanks: Array.isArray(q.blanks) && q.blanks.length > 0 ? q.blanks : [''],
-        points: typeof q.points === 'number' ? q.points : 1,
-      };
-    });
-    setForm({
-      title: item.title ?? '',
-      description: item.description ?? '',
-      score: Number(item.score) ?? 10,
-      quarter: item.quarter ?? '1',
-      questions: questions.length ? questions : [{ ...DEFAULT_QUESTION }],
-    });
-    setModalOpen(true);
-  };
+    if (!draft.title.trim()) {
+      errors.push('Assessment title is required.')
+    }
+    if (draft.questions.length === 0) {
+      errors.push('Add at least one question to the canvas.')
+    }
+
+    draft.questions.forEach((question, index) => {
+      const label = `Question ${index + 1}`
+      if (!question.prompt.trim()) {
+        errors.push(`${label} needs a prompt.`)
+      }
+      if (question.points <= 0) {
+        errors.push(`${label} points must be greater than 0.`)
+      }
+
+      if (question.type === 'single_choice' || question.type === 'multiple_choice') {
+        const normalizedChoices = question.choices.map((choice) => choice.trim()).filter(Boolean)
+        if (normalizedChoices.length < 2) {
+          errors.push(`${label} needs at least two choices.`)
+        }
+        if (question.correctAnswers.length === 0) {
+          errors.push(`${label} needs at least one correct choice.`)
+        }
+      }
+
+      if (question.type === 'fill_in_the_blanks') {
+        const blanks = question.blanks.map((blank) => blank.trim()).filter(Boolean)
+        if (blanks.length === 0) {
+          errors.push(`${label} needs at least one blank answer.`)
+        }
+      }
+    })
+
+    return errors
+  }, [draft])
+
+  const canSave =
+    !!draft &&
+    validationErrors.length === 0 &&
+    !saveCreateMutation.isPending &&
+    !saveUpdateMutation.isPending &&
+    !!firstEcrId
+
+  const updateDraft = (updater: (current: BuilderDraft) => BuilderDraft) => {
+    setDraft((current) => (current ? updater(current) : current))
+  }
+
+  const updateQuestion = (questionId: string, updater: (question: AssessmentMethodQuestion) => AssessmentMethodQuestion) => {
+    updateDraft((current) => ({
+      ...current,
+      questions: current.questions.map((question) =>
+        question.id === questionId ? updater(question) : question
+      ),
+    }))
+  }
+
+  const addQuestion = (type: AssessmentQuestionType, insertAt?: number) => {
+    updateDraft((current) => {
+      const nextQuestions = [...current.questions]
+      const question = makeQuestion(type)
+      if (insertAt == null || insertAt < 0 || insertAt >= nextQuestions.length) {
+        nextQuestions.push(question)
+      } else {
+        nextQuestions.splice(insertAt, 0, question)
+      }
+      return { ...current, questions: nextQuestions }
+    })
+  }
+
+  const removeQuestion = (questionId: string) => {
+    updateDraft((current) => ({
+      ...current,
+      questions: current.questions.filter((question) => question.id !== questionId),
+    }))
+  }
+
+  const openCreateBuilder = () => {
+    if (!firstEcrId) return
+    setDraft(newDraft(activeType, firstEcrId))
+    setBuilderOpen(true)
+  }
+
+  const openEditBuilder = (assessment: AssessmentMethod) => {
+    setActiveType(assessment.type)
+    setDraft(draftFromAssessment(assessment))
+    setBuilderOpen(true)
+  }
+
+  const closeBuilder = () => {
+    setBuilderOpen(false)
+    setDraft(null)
+    setActiveDragId(null)
+  }
 
   const handleSave = () => {
-    if (!firstEcrId) return;
-    const payload: Omit<SubjectEcrItem, 'id'> = {
-      subject_ecr_id: firstEcrId,
-      type: builderType,
-      title: form.title.trim(),
-      description: form.description.trim() || undefined,
-      score: form.score,
-      quarter: form.quarter,
-      content:
-        form.questions.length > 0
-          ? {
-              questions: form.questions.map((q) => {
-                const base = { type: q.type, question: q.question.trim(), points: q.points };
-                if (q.type === 'true_false') {
-                  return { ...base, choices: ['True', 'False'], answer: q.answer };
-                }
-                if (q.type === 'single_choice') {
-                  return {
-                    ...base,
-                    choices: q.choices.filter((c) => c.trim().length > 0),
-                    answer: q.answer.trim().charAt(0).toUpperCase() || 'A',
-                  };
-                }
-                if (q.type === 'multiple_choice') {
-                  return {
-                    ...base,
-                    choices: q.choices.filter((c) => c.trim().length > 0),
-                    answer: q.answerMultiple.filter(Boolean).length > 0 ? q.answerMultiple.filter(Boolean) : [q.answer],
-                  };
-                }
-                if (q.type === 'fill_in_the_blanks') {
-                  return { ...base, blanks: q.blanks.filter((b) => b.trim().length > 0).map((b) => b.trim()) };
-                }
-                return { ...base, choices: q.choices, answer: q.answer };
-              }),
-            }
-          : undefined,
-    };
-    if (editingItem?.id) {
-      updateMutation.mutate({ id: editingItem.id, data: payload });
+    if (!draft) return
+    const payload: AssessmentMethodInput = {
+      subjectEcrId: draft.subjectEcrId || firstEcrId || '',
+      type: draft.type,
+      status: draft.status,
+      title: draft.title,
+      description: draft.description,
+      quarter: draft.quarter,
+      scheduledDate: draft.scheduledDate || null,
+      openAt: draft.openAt || null,
+      closeAt: draft.closeAt || null,
+      dueAt: draft.dueAt || null,
+      allowLateSubmission: draft.allowLateSubmission,
+      rules: draft.rules,
+      questions: draft.questions,
+    }
+
+    if (draft.id) {
+      saveUpdateMutation.mutate({ id: draft.id, payload })
     } else {
-      createMutation.mutate(payload);
+      saveCreateMutation.mutate(payload)
     }
-  };
+  }
 
-  const setQuestion = (index: number, field: keyof QuestionForm, value: any) => {
-    const next = form.questions.map((q, i) =>
-      i !== index ? q : { ...q, [field]: value }
-    );
-    if (field === 'type') {
-      const newType = value as QuestionType;
-      const q = next[index];
-      if (newType === 'true_false') {
-        q.choices = ['True', 'False'];
-        q.answer = 'True';
-        q.answerMultiple = [];
-        q.blanks = [''];
-      } else if (newType === 'single_choice') {
-        q.choices = q.choices?.length ? q.choices : ['A. ', 'B. ', 'C. ', 'D. '];
-        q.answer = q.answer?.charAt(0).toUpperCase() || 'A';
-        q.answerMultiple = [];
-        q.blanks = [''];
-      } else if (newType === 'multiple_choice') {
-        q.choices = q.choices?.length ? q.choices : ['A. ', 'B. ', 'C. ', 'D. '];
-        q.answerMultiple = q.answerMultiple?.length ? q.answerMultiple : [];
-        q.blanks = [''];
-      } else {
-        q.blanks = q.blanks?.length ? q.blanks : [''];
-        q.answerMultiple = [];
-      }
+  const handleDragStart = (event: DragStartEvent) => {
+    setActiveDragId(String(event.active.id))
+  }
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    setActiveDragId(null)
+    if (!draft || !event.over) return
+
+    const activeId = String(event.active.id)
+    const overId = String(event.over.id)
+
+    if (activeId.startsWith(PALETTE_PREFIX)) {
+      const type = activeId.replace(PALETTE_PREFIX, '') as AssessmentQuestionType
+      const insertIndex = draft.questions.findIndex((question) => question.id === overId)
+      addQuestion(type, overId === CANVAS_DROP_ID ? undefined : insertIndex)
+      return
     }
-    setForm({ ...form, questions: next });
-  };
 
-  const setBlank = (qIndex: number, blankIndex: number, value: string) => {
-    const next = [...form.questions];
-    const blanks = [...(next[qIndex].blanks ?? [])];
-    blanks[blankIndex] = value;
-    next[qIndex].blanks = blanks;
-    setForm({ ...form, questions: next });
-  };
+    const oldIndex = draft.questions.findIndex((question) => question.id === activeId)
+    const newIndex = draft.questions.findIndex((question) => question.id === overId)
+    if (oldIndex === -1 || newIndex === -1 || oldIndex === newIndex) return
 
-  const addBlank = (qIndex: number) => {
-    const next = [...form.questions];
-    next[qIndex].blanks = [...(next[qIndex].blanks ?? []), ''];
-    setForm({ ...form, questions: next });
-  };
+    updateDraft((current) => ({
+      ...current,
+      questions: arrayMove(current.questions, oldIndex, newIndex),
+    }))
+  }
 
-  const removeBlank = (qIndex: number, blankIndex: number) => {
-    const next = [...form.questions];
-    next[qIndex].blanks = (next[qIndex].blanks ?? []).filter((_, i) => i !== blankIndex);
-    setForm({ ...form, questions: next });
-  };
-
-  const toggleMultipleAnswer = (qIndex: number, letter: string) => {
-    const next = [...form.questions];
-    const arr = next[qIndex].answerMultiple ?? [];
-    const set = new Set(arr);
-    if (set.has(letter)) set.delete(letter);
-    else set.add(letter);
-    next[qIndex].answerMultiple = Array.from(set).sort();
-    setForm({ ...form, questions: next });
-  };
-
-  const addQuestion = () => {
-    setForm({ ...form, questions: [...form.questions, { ...DEFAULT_QUESTION }] });
-  };
-
-  const removeQuestion = (index: number) => {
-    setForm({
-      ...form,
-      questions: form.questions.filter((_, i) => i !== index),
-    });
-  };
-
-  const types: { id: AssessmentType; label: string }[] = [
-    { id: 'quiz', label: 'Quiz' },
-    { id: 'assignment', label: 'Assignment' },
-    { id: 'exam', label: 'Exam' },
-  ];
+  const currentDragType = useMemo(() => {
+    if (!activeDragId || !activeDragId.startsWith(PALETTE_PREFIX)) return null
+    return activeDragId.replace(PALETTE_PREFIX, '') as AssessmentQuestionType
+  }, [activeDragId])
 
   return (
     <div className="space-y-4">
       {!firstEcrId && (
-        <p className="text-amber-700 bg-amber-50 border border-amber-200 rounded-lg p-3 text-sm">
-          Set &quot;Components of Summative Assessment&quot; first so this subject has an ECR category (e.g. Written Works) to attach quizzes/assignments/exams to.
-        </p>
+        <div className="rounded-xl border border-amber-200 bg-amber-50 p-3 text-sm text-amber-700">
+          Create your <strong>Components of Summative Assessment</strong> first so assessment methods can be attached to an ECR component.
+        </div>
       )}
-      <div className="flex flex-wrap gap-2">
-        {types.map((t) => (
-          <button
-            key={t.id}
-            type="button"
-            onClick={() => setBuilderType(t.id)}
-            className={`px-4 py-2 rounded-lg text-sm font-medium ${
-              builderType === t.id
-                ? 'bg-indigo-600 text-white'
-                : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
-            }`}
-          >
-            {t.label}
-          </button>
-        ))}
-      </div>
-      <div className="flex items-center justify-between">
-        <h3 className="text-lg font-semibold text-gray-900">
-          {builderType.charAt(0).toUpperCase() + builderType.slice(1)}s
-        </h3>
+
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex flex-wrap gap-2">
+          {TYPE_OPTIONS.map((option) => (
+            <button
+              key={option.id}
+              type="button"
+              onClick={() => setActiveType(option.id)}
+              className={clsx(
+                'rounded-lg px-4 py-2 text-sm font-medium transition',
+                activeType === option.id
+                  ? 'bg-indigo-600 text-white'
+                  : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
+              )}
+            >
+              {option.label}
+            </button>
+          ))}
+        </div>
         <Button
           type="button"
-          onClick={openCreate}
+          onClick={openCreateBuilder}
           disabled={!firstEcrId}
           className="inline-flex items-center gap-2"
         >
-          <PlusIcon className="w-4 h-4" />
-          Add {builderType.charAt(0).toUpperCase() + builderType.slice(1)}
+          <PlusIcon className="h-4 w-4" />
+          Add {TYPE_OPTIONS.find((option) => option.id === activeType)?.label}
         </Button>
       </div>
+
       {isLoading ? (
-        <div className="py-8 text-center text-gray-500">Loading...</div>
-      ) : items.length === 0 ? (
-        <div className="border-2 border-dashed border-gray-200 rounded-lg p-8 text-center text-gray-500">
-          No {builderType}s yet. Add one to let students take it interactively (with live score).
+        <div className="py-10 text-center text-sm text-gray-500">Loading assessment methods...</div>
+      ) : methods.length === 0 ? (
+        <div className="rounded-xl border-2 border-dashed border-gray-200 bg-gray-50 p-10 text-center text-sm text-gray-500">
+          No {activeType}s yet. Create one and build questions with drag and drop.
         </div>
       ) : (
-        <ul className="space-y-2">
-          {items.map((item) => (
-            <li
-              key={item.id}
-              className="flex items-center justify-between gap-4 p-4 bg-white border border-gray-200 rounded-lg hover:border-indigo-200"
-            >
-              <div className="flex-1 min-w-0">
-                <div className="flex items-center gap-2 flex-wrap">
-                  <span className="font-medium text-gray-900">{item.title}</span>
-                  {item.quarter && (
-                    <Badge color="zinc">Q{item.quarter}</Badge>
-                  )}
-                  {item.content?.questions?.length != null && item.content.questions.length > 0 && (
-                    <span className="text-xs text-gray-500">
-                      {item.content.questions.length} question(s)
-                    </span>
-                  )}
+        <ul className="space-y-3">
+          {methods.map((method) => {
+            const points = method.questions.reduce((sum, question) => sum + question.points, 0)
+            return (
+              <li
+                key={method.id}
+                className="rounded-xl border border-gray-200 bg-white p-4 shadow-sm transition hover:border-indigo-200"
+              >
+                <div className="flex items-start justify-between gap-4">
+                  <div className="min-w-0 flex-1">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <h4 className="truncate font-semibold text-gray-900">{method.title}</h4>
+                      <Badge color={method.status === 'published' ? 'green' : 'amber'}>
+                        {method.status === 'published' ? 'Published' : 'Draft'}
+                      </Badge>
+                      <Badge color="zinc">Q{method.quarter}</Badge>
+                    </div>
+                    {method.description && (
+                      <p className="mt-1 line-clamp-2 text-sm text-gray-600">{method.description}</p>
+                    )}
+                    <div className="mt-3 flex flex-wrap items-center gap-3 text-xs text-gray-500">
+                      <span className="inline-flex items-center gap-1">
+                        <DocumentTextIcon className="h-4 w-4" />
+                        {method.questions.length} question(s)
+                      </span>
+                      <span className="inline-flex items-center gap-1">
+                        <ClockIcon className="h-4 w-4" />
+                        {points} point(s)
+                      </span>
+                      <span className="inline-flex items-center gap-1">
+                        <CalendarDaysIcon className="h-4 w-4" />
+                        Due: {formatDateTime(method.dueAt)}
+                      </span>
+                    </div>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <button
+                      type="button"
+                      onClick={() => openEditBuilder(method)}
+                      className="rounded-md p-2 text-gray-500 transition hover:bg-indigo-50 hover:text-indigo-600"
+                      title="Edit"
+                    >
+                      <PencilIcon className="h-4 w-4" />
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        if (!method.id) return
+                        if (window.confirm('Delete this assessment method?')) {
+                          deleteMutation.mutate(method.id)
+                        }
+                      }}
+                      className="rounded-md p-2 text-gray-500 transition hover:bg-red-50 hover:text-red-600"
+                      title="Delete"
+                    >
+                      <TrashIcon className="h-4 w-4" />
+                    </button>
+                  </div>
                 </div>
-                {item.description && (
-                  <p className="text-sm text-gray-600 mt-1 truncate">{item.description}</p>
-                )}
-              </div>
-              <div className="flex items-center gap-2">
-                <button
-                  type="button"
-                  onClick={() => openEdit(item)}
-                  className="p-2 text-gray-500 hover:text-indigo-600 rounded"
-                  title="Edit"
-                >
-                  <PencilIcon className="w-4 h-4" />
-                </button>
-                <button
-                  type="button"
-                  onClick={() => {
-                    if (window.confirm('Delete this item?')) deleteMutation.mutate(item.id!);
-                  }}
-                  className="p-2 text-gray-500 hover:text-red-600 rounded"
-                  title="Delete"
-                >
-                  <TrashIcon className="w-4 h-4" />
-                </button>
-              </div>
-            </li>
-          ))}
+              </li>
+            )
+          })}
         </ul>
       )}
 
-      {/* Modal */}
-      {modalOpen && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/50">
-          <div className="bg-white rounded-xl shadow-xl max-w-2xl w-full max-h-[90vh] overflow-y-auto">
-            <div className="p-6 border-b border-gray-200 flex items-center justify-between">
-              <h3 className="text-lg font-semibold">
-                {editingItem ? 'Edit' : 'Add'} {builderType.charAt(0).toUpperCase() + builderType.slice(1)}
-              </h3>
-              <button type="button" onClick={closeModal} className="text-gray-400 hover:text-gray-600">
-                ×
-              </button>
-            </div>
-            <div className="p-6 space-y-4">
+      {builderOpen && draft && (
+        <div className="fixed inset-0 z-50 bg-black/50">
+          <div className="absolute inset-0 flex flex-col bg-white">
+            <header className="flex items-center justify-between border-b border-gray-200 px-6 py-4">
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">Title</label>
-                <Input
-                  value={form.title}
-                  onChange={(e) => setForm({ ...form, title: e.target.value })}
-                  placeholder="e.g. Quiz 1: Operations"
-                />
+                <h3 className="text-lg font-semibold text-gray-900">
+                  {draft.id ? 'Edit' : 'Create'} {draft.type.charAt(0).toUpperCase() + draft.type.slice(1)}
+                </h3>
+                <p className="text-sm text-gray-500">
+                  Tutor-style builder: drag question types into canvas, then configure details.
+                </p>
               </div>
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">Description (optional)</label>
-                <Input
-                  value={form.description}
-                  onChange={(e) => setForm({ ...form, description: e.target.value })}
-                  placeholder="Brief description"
-                />
+              <div className="flex items-center gap-2">
+                <Button type="button" variant="outline" onClick={closeBuilder}>
+                  Cancel
+                </Button>
+                <Button type="button" onClick={handleSave} disabled={!canSave}>
+                  {draft.id ? 'Save Changes' : 'Create Assessment'}
+                </Button>
+                <button
+                  type="button"
+                  onClick={closeBuilder}
+                  className="rounded-md p-2 text-gray-500 transition hover:bg-gray-100"
+                >
+                  <XMarkIcon className="h-5 w-5" />
+                </button>
               </div>
-              <div className="grid grid-cols-2 gap-4">
-                <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-1">Total score</label>
-                  <Input
-                    type="number"
-                    min={0}
-                    value={form.score}
-                    onChange={(e) => setForm({ ...form, score: Number(e.target.value) || 0 })}
-                  />
-                </div>
-                <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-1">Quarter</label>
-                  <select
-                    className="w-full border border-gray-300 rounded-md px-3 py-2 text-sm"
-                    value={form.quarter}
-                    onChange={(e) => setForm({ ...form, quarter: e.target.value })}
-                  >
-                    {['1', '2', '3', '4'].map((q) => (
-                      <option key={q} value={q}>Q{q}</option>
+            </header>
+
+            <DndContext
+              sensors={sensors}
+              collisionDetection={closestCenter}
+              onDragStart={handleDragStart}
+              onDragEnd={handleDragEnd}
+            >
+              <div className="grid min-h-0 flex-1 grid-cols-1 gap-4 bg-gray-50 p-4 lg:grid-cols-[18rem_minmax(0,1fr)_22rem]">
+                <aside className="min-h-0 overflow-y-auto rounded-xl border border-gray-200 bg-white p-4">
+                  <h4 className="text-sm font-semibold text-gray-900">Question Types</h4>
+                  <p className="mt-1 text-xs text-gray-500">
+                    Drag any block into the canvas.
+                  </p>
+                  <div className="mt-4 space-y-2">
+                    {QUESTION_TYPE_OPTIONS.map((option) => (
+                      <PaletteCard
+                        key={option.type}
+                        type={option.type}
+                        label={option.label}
+                        hint={option.hint}
+                      />
                     ))}
-                  </select>
-                </div>
-              </div>
-              <div>
-                <div className="flex items-center justify-between mb-2">
-                  <label className="block text-sm font-medium text-gray-700">Questions</label>
-                  <Button type="button" variant="outline" size="sm" onClick={addQuestion}>
-                    <PlusIcon className="w-4 h-4 mr-1" /> Add question
-                  </Button>
-                </div>
-                <div className="space-y-4">
-                  {form.questions.map((q, idx) => (
-                    <div key={idx} className="border border-gray-200 rounded-lg p-4 bg-gray-50">
-                      <div className="flex justify-between items-start gap-2 mb-2">
-                        <span className="text-sm font-medium text-gray-700">Question {idx + 1}</span>
-                        <button
-                          type="button"
-                          onClick={() => removeQuestion(idx)}
-                          className="text-red-600 text-sm hover:underline"
-                        >
-                          Remove
-                        </button>
-                      </div>
-                      <div className="mb-2">
-                        <label className="block text-xs text-gray-500 mb-1">Type</label>
+                  </div>
+                </aside>
+
+                <CanvasPanel
+                  draft={draft}
+                  onTypeChange={(questionId, type) =>
+                    updateQuestion(questionId, (question) => {
+                      const base = makeQuestion(type)
+                      return {
+                        ...base,
+                        id: question.id,
+                        prompt: question.prompt,
+                        points: question.points,
+                      }
+                    })
+                  }
+                  onPromptChange={(questionId, prompt) =>
+                    updateQuestion(questionId, (question) => ({ ...question, prompt }))
+                  }
+                  onPointsChange={(questionId, points) =>
+                    updateQuestion(questionId, (question) => ({ ...question, points }))
+                  }
+                  onRemove={removeQuestion}
+                  onChoiceChange={(questionId, index, value) =>
+                    updateQuestion(questionId, (question) => {
+                      const nextChoices = [...question.choices]
+                      nextChoices[index] = value
+                      return { ...question, choices: nextChoices }
+                    })
+                  }
+                  onAddChoice={(questionId) =>
+                    updateQuestion(questionId, (question) => ({
+                      ...question,
+                      choices: [...question.choices, ''],
+                    }))
+                  }
+                  onRemoveChoice={(questionId, index) =>
+                    updateQuestion(questionId, (question) => {
+                      const nextChoices = question.choices.filter((_, choiceIndex) => choiceIndex !== index)
+                      const validLetters = new Set(nextChoices.map((_, choiceIndex) => choiceLetter(choiceIndex)))
+                      const nextCorrect = question.correctAnswers.filter((answer) => validLetters.has(answer))
+                      return {
+                        ...question,
+                        choices: nextChoices,
+                        correctAnswers: nextCorrect.length ? nextCorrect : [choiceLetter(0)],
+                      }
+                    })
+                  }
+                  onToggleCorrectChoice={(questionId, letter, allowMultiple) =>
+                    updateQuestion(questionId, (question) => {
+                      if (!allowMultiple) {
+                        return { ...question, correctAnswers: [letter] }
+                      }
+                      const set = new Set(question.correctAnswers)
+                      if (set.has(letter)) set.delete(letter)
+                      else set.add(letter)
+                      return {
+                        ...question,
+                        correctAnswers: Array.from(set).sort(),
+                      }
+                    })
+                  }
+                  onTrueFalseChange={(questionId, value) =>
+                    updateQuestion(questionId, (question) => ({ ...question, correctAnswers: [value] }))
+                  }
+                  onBlankChange={(questionId, index, value) =>
+                    updateQuestion(questionId, (question) => {
+                      const nextBlanks = [...question.blanks]
+                      nextBlanks[index] = value
+                      return { ...question, blanks: nextBlanks }
+                    })
+                  }
+                  onAddBlank={(questionId) =>
+                    updateQuestion(questionId, (question) => ({
+                      ...question,
+                      blanks: [...question.blanks, ''],
+                    }))
+                  }
+                  onRemoveBlank={(questionId, index) =>
+                    updateQuestion(questionId, (question) => ({
+                      ...question,
+                      blanks: question.blanks.filter((_, blankIndex) => blankIndex !== index),
+                    }))
+                  }
+                  onSampleAnswerChange={(questionId, value) =>
+                    updateQuestion(questionId, (question) => ({ ...question, sampleAnswer: value }))
+                  }
+                />
+
+                <aside className="min-h-0 overflow-y-auto rounded-xl border border-gray-200 bg-white p-4">
+                  <h4 className="text-sm font-semibold text-gray-900">Assessment Settings</h4>
+                  <div className="mt-4 space-y-4">
+                    <div>
+                      <label className="mb-1 block text-xs font-medium text-gray-600">Assessment Type</label>
+                      <select
+                        className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm"
+                        value={draft.type}
+                        onChange={(event) => {
+                          const nextType = event.target.value as AssessmentMethodType
+                          updateDraft((current) => ({
+                            ...current,
+                            type: nextType,
+                            rules: { ...DEFAULT_RULES_BY_TYPE[nextType] },
+                          }))
+                        }}
+                      >
+                        {TYPE_OPTIONS.map((option) => (
+                          <option key={option.id} value={option.id}>
+                            {option.label}
+                          </option>
+                        ))}
+                      </select>
+                    </div>
+
+                    <Input
+                      label="Title"
+                      placeholder="e.g. Quiz 1 - Fractions"
+                      value={draft.title}
+                      onChange={(event) =>
+                        updateDraft((current) => ({ ...current, title: event.target.value }))
+                      }
+                    />
+
+                    <div>
+                      <label className="mb-1 block text-xs font-medium text-gray-600">Description</label>
+                      <textarea
+                        className="min-h-20 w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                        value={draft.description}
+                        onChange={(event) =>
+                          updateDraft((current) => ({ ...current, description: event.target.value }))
+                        }
+                        placeholder="Optional instructions for students"
+                      />
+                    </div>
+
+                    <div className="grid grid-cols-2 gap-2">
+                      <div>
+                        <label className="mb-1 block text-xs font-medium text-gray-600">Quarter</label>
                         <select
-                          className="w-full border border-gray-300 rounded-md px-3 py-2 text-sm"
-                          value={q.type}
-                          onChange={(e) => setQuestion(idx, 'type', e.target.value as QuestionType)}
+                          className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm"
+                          value={draft.quarter}
+                          onChange={(event) =>
+                            updateDraft((current) => ({ ...current, quarter: event.target.value }))
+                          }
                         >
-                          {(Object.keys(QUESTION_TYPE_LABELS) as QuestionType[]).map((t) => (
-                            <option key={t} value={t}>{QUESTION_TYPE_LABELS[t]}</option>
+                          {['1', '2', '3', '4'].map((quarter) => (
+                            <option key={quarter} value={quarter}>
+                              Q{quarter}
+                            </option>
                           ))}
                         </select>
                       </div>
-                      <Input
-                        className="mb-2"
-                        value={q.question}
-                        onChange={(e) => setQuestion(idx, 'question', e.target.value)}
-                        placeholder={q.type === 'fill_in_the_blanks' ? 'e.g. The capital of Philippines is _____.' : 'Question text'}
-                      />
-                      {q.type === 'true_false' && (
-                        <div className="mb-2">
-                          <label className="block text-xs text-gray-500 mb-1">Correct answer</label>
-                          <select
-                            className="w-full border border-gray-300 rounded px-2 py-1 text-sm"
-                            value={q.answer}
-                            onChange={(e) => setQuestion(idx, 'answer', e.target.value)}
-                          >
-                            <option value="True">True</option>
-                            <option value="False">False</option>
-                          </select>
-                        </div>
-                      )}
-                      {(q.type === 'single_choice' || q.type === 'multiple_choice') && (
-                        <>
-                          <div className="space-y-1 mb-2">
-                            <label className="block text-xs text-gray-500 mb-1">Choices</label>
-                            {(q.choices ?? []).map((choice, cIdx) => (
-                              <Input
-                                key={cIdx}
-                                value={choice}
-                                onChange={(e) => {
-                                  const next = [...(q.choices ?? [])];
-                                  next[cIdx] = e.target.value;
-                                  setQuestion(idx, 'choices', next);
-                                }}
-                                placeholder={`Choice ${String.fromCharCode(65 + cIdx)}`}
-                              />
-                            ))}
-                          </div>
-                          {q.type === 'single_choice' && (
-                            <div className="mb-2">
-                              <label className="block text-xs text-gray-500 mb-1">Correct answer</label>
-                              <select
-                                className="w-full border border-gray-300 rounded px-2 py-1 text-sm"
-                                value={q.answer}
-                                onChange={(e) => setQuestion(idx, 'answer', e.target.value)}
-                              >
-                                {(q.choices ?? []).map((_, cIdx) => (
-                                  <option key={cIdx} value={String.fromCharCode(65 + cIdx)}>{String.fromCharCode(65 + cIdx)}</option>
-                                ))}
-                              </select>
-                            </div>
-                          )}
-                          {q.type === 'multiple_choice' && (
-                            <div className="mb-2">
-                              <label className="block text-xs text-gray-500 mb-1">Correct answer(s) (select all that apply)</label>
-                              <div className="flex flex-wrap gap-2">
-                                {(q.choices ?? []).map((_, cIdx) => {
-                                  const letter = String.fromCharCode(65 + cIdx);
-                                  const checked = (q.answerMultiple ?? []).includes(letter);
-                                  return (
-                                    <label key={cIdx} className="inline-flex items-center gap-1 cursor-pointer">
-                                      <input
-                                        type="checkbox"
-                                        checked={checked}
-                                        onChange={() => toggleMultipleAnswer(idx, letter)}
-                                        className="rounded border-gray-300 text-indigo-600"
-                                      />
-                                      <span className="text-sm">{letter}</span>
-                                    </label>
-                                  );
-                                })}
-                              </div>
-                            </div>
-                          )}
-                        </>
-                      )}
-                      {q.type === 'fill_in_the_blanks' && (
-                        <div className="mb-2">
-                          <label className="block text-xs text-gray-500 mb-1">Correct answers for each blank (in order)</label>
-                          <p className="text-xs text-gray-400 mb-1">Use <code className="bg-gray-100 px-1 rounded"> | </code> to allow multiple acceptable answers, e.g. Manila | Manila City</p>
-                          <div className="space-y-1">
-                            {(q.blanks ?? ['']).map((blank, bIdx) => (
-                              <div key={bIdx} className="flex gap-2 items-center">
-                                <Input
-                                  value={blank}
-                                  onChange={(e) => setBlank(idx, bIdx, e.target.value)}
-                                  placeholder={`Blank ${bIdx + 1}`}
-                                  className="flex-1"
-                                />
-                                <button
-                                  type="button"
-                                  onClick={() => removeBlank(idx, bIdx)}
-                                  className="text-red-600 text-sm hover:underline"
-                                >
-                                  Remove
-                                </button>
-                              </div>
-                            ))}
-                            <button
-                              type="button"
-                              onClick={() => addBlank(idx)}
-                              className="text-indigo-600 text-sm hover:underline"
-                            >
-                              + Add blank
-                            </button>
-                          </div>
-                        </div>
-                      )}
                       <div>
-                        <label className="block text-xs text-gray-500 mb-1">Points</label>
-                        <Input
-                          type="number"
-                          min={0}
-                          step={0.5}
-                          value={q.points}
-                          onChange={(e) => setQuestion(idx, 'points', Number(e.target.value) || 0)}
-                          className="w-20"
-                        />
+                        <label className="mb-1 block text-xs font-medium text-gray-600">Status</label>
+                        <select
+                          className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm"
+                          value={draft.status}
+                          onChange={(event) =>
+                            updateDraft((current) => ({
+                              ...current,
+                              status: event.target.value as AssessmentPublishStatus,
+                            }))
+                          }
+                        >
+                          <option value="draft">Draft</option>
+                          <option value="published">Published</option>
+                        </select>
                       </div>
                     </div>
-                  ))}
-                </div>
+
+                    <div className="rounded-lg border border-gray-200 p-3">
+                      <p className="text-xs font-semibold uppercase tracking-wide text-gray-500">Schedule</p>
+                      <div className="mt-3 space-y-2">
+                        <div>
+                          <label className="mb-1 block text-xs font-medium text-gray-600">Scheduled Date</label>
+                          <Input
+                            type="date"
+                            value={draft.scheduledDate}
+                            onChange={(event) =>
+                              updateDraft((current) => ({
+                                ...current,
+                                scheduledDate: event.target.value,
+                              }))
+                            }
+                          />
+                        </div>
+                        <div>
+                          <label className="mb-1 block text-xs font-medium text-gray-600">Open At</label>
+                          <Input
+                            type="datetime-local"
+                            value={draft.openAt}
+                            onChange={(event) =>
+                              updateDraft((current) => ({ ...current, openAt: event.target.value }))
+                            }
+                          />
+                        </div>
+                        <div>
+                          <label className="mb-1 block text-xs font-medium text-gray-600">Close At</label>
+                          <Input
+                            type="datetime-local"
+                            value={draft.closeAt}
+                            onChange={(event) =>
+                              updateDraft((current) => ({ ...current, closeAt: event.target.value }))
+                            }
+                          />
+                        </div>
+                        <div>
+                          <label className="mb-1 block text-xs font-medium text-gray-600">Due At</label>
+                          <Input
+                            type="datetime-local"
+                            value={draft.dueAt}
+                            onChange={(event) =>
+                              updateDraft((current) => ({ ...current, dueAt: event.target.value }))
+                            }
+                          />
+                        </div>
+                        <div className="flex items-center justify-between rounded-lg border border-gray-200 px-3 py-2">
+                          <span className="text-xs font-medium text-gray-700">Allow late submission</span>
+                          <Switch
+                            checked={draft.allowLateSubmission}
+                            onChange={(value) =>
+                              updateDraft((current) => ({ ...current, allowLateSubmission: Boolean(value) }))
+                            }
+                            color="indigo"
+                          />
+                        </div>
+                      </div>
+                    </div>
+
+                    <div className="rounded-lg border border-gray-200 p-3">
+                      <p className="text-xs font-semibold uppercase tracking-wide text-gray-500">Rules</p>
+                      <div className="mt-3 space-y-2">
+                        <div>
+                          <label className="mb-1 block text-xs font-medium text-gray-600">Max Attempts</label>
+                          <Input
+                            type="number"
+                            min={1}
+                            value={draft.rules.maxAttempts}
+                            onChange={(event) =>
+                              updateDraft((current) => ({
+                                ...current,
+                                rules: {
+                                  ...current.rules,
+                                  maxAttempts: Math.max(1, Number(event.target.value) || 1),
+                                },
+                              }))
+                            }
+                          />
+                        </div>
+                        <div>
+                          <label className="mb-1 block text-xs font-medium text-gray-600">Time Limit (minutes)</label>
+                          <Input
+                            type="number"
+                            min={1}
+                            value={draft.rules.timeLimitMinutes ?? ''}
+                            onChange={(event) =>
+                              updateDraft((current) => ({
+                                ...current,
+                                rules: {
+                                  ...current.rules,
+                                  timeLimitMinutes:
+                                    event.target.value === '' ? null : Math.max(1, Number(event.target.value) || 1),
+                                },
+                              }))
+                            }
+                            placeholder="No limit"
+                          />
+                        </div>
+                        <div>
+                          <label className="mb-1 block text-xs font-medium text-gray-600">Pass Mark (%)</label>
+                          <Input
+                            type="number"
+                            min={0}
+                            max={100}
+                            value={draft.rules.passMark ?? ''}
+                            onChange={(event) =>
+                              updateDraft((current) => ({
+                                ...current,
+                                rules: {
+                                  ...current.rules,
+                                  passMark:
+                                    event.target.value === ''
+                                      ? null
+                                      : Math.max(0, Math.min(100, Number(event.target.value) || 0)),
+                                },
+                              }))
+                            }
+                            placeholder="Optional"
+                          />
+                        </div>
+                        <div className="flex items-center justify-between rounded-lg border border-gray-200 px-3 py-2">
+                          <span className="text-xs font-medium text-gray-700">Randomize questions</span>
+                          <Switch
+                            checked={draft.rules.randomizeQuestions}
+                            onChange={(value) =>
+                              updateDraft((current) => ({
+                                ...current,
+                                rules: { ...current.rules, randomizeQuestions: Boolean(value) },
+                              }))
+                            }
+                            color="indigo"
+                          />
+                        </div>
+                      </div>
+                    </div>
+
+                    <div className="rounded-lg border border-indigo-100 bg-indigo-50 p-3">
+                      <p className="text-xs font-semibold uppercase tracking-wide text-indigo-700">Summary</p>
+                      <p className="mt-1 text-sm text-indigo-800">{draft.questions.length} question(s)</p>
+                      <p className="text-sm text-indigo-800">{totalPoints} total point(s)</p>
+                    </div>
+                  </div>
+                </aside>
               </div>
-            </div>
-            <div className="p-6 border-t border-gray-200 flex justify-end gap-2">
-              <Button type="button" variant="outline" onClick={closeModal}>
-                Cancel
-              </Button>
-              <Button
-                type="button"
-                onClick={handleSave}
-                disabled={!form.title.trim() || createMutation.isPending || updateMutation.isPending}
-              >
-                {editingItem ? 'Update' : 'Create'}
-              </Button>
-            </div>
+
+              <DragOverlay>
+                {currentDragType ? (
+                  <div className="rounded-xl border border-indigo-300 bg-indigo-50 px-3 py-2 text-sm font-semibold text-indigo-700 shadow">
+                    {QUESTION_TYPE_LABELS[currentDragType]}
+                  </div>
+                ) : null}
+              </DragOverlay>
+            </DndContext>
+
+            {validationErrors.length > 0 && (
+              <div className="border-t border-red-100 bg-red-50 px-6 py-3">
+                <ul className="list-disc space-y-1 pl-5 text-xs text-red-700">
+                  {validationErrors.slice(0, 4).map((error) => (
+                    <li key={error}>{error}</li>
+                  ))}
+                  {validationErrors.length > 4 && <li>+ {validationErrors.length - 4} more issue(s)</li>}
+                </ul>
+              </div>
+            )}
           </div>
         </div>
       )}
     </div>
-  );
-};
+  )
+}
 
-export default AssessmentBuilderTab;
+const CanvasPanel: React.FC<{
+  draft: BuilderDraft
+  onTypeChange: (id: string, type: AssessmentQuestionType) => void
+  onPromptChange: (id: string, prompt: string) => void
+  onPointsChange: (id: string, points: number) => void
+  onRemove: (id: string) => void
+  onChoiceChange: (id: string, index: number, value: string) => void
+  onAddChoice: (id: string) => void
+  onRemoveChoice: (id: string, index: number) => void
+  onToggleCorrectChoice: (id: string, letter: string, allowMultiple: boolean) => void
+  onTrueFalseChange: (id: string, value: 'True' | 'False') => void
+  onBlankChange: (id: string, index: number, value: string) => void
+  onAddBlank: (id: string) => void
+  onRemoveBlank: (id: string, index: number) => void
+  onSampleAnswerChange: (id: string, value: string) => void
+}> = ({
+  draft,
+  onTypeChange,
+  onPromptChange,
+  onPointsChange,
+  onRemove,
+  onChoiceChange,
+  onAddChoice,
+  onRemoveChoice,
+  onToggleCorrectChoice,
+  onTrueFalseChange,
+  onBlankChange,
+  onAddBlank,
+  onRemoveBlank,
+  onSampleAnswerChange,
+}) => {
+  const { setNodeRef, isOver } = useDroppable({ id: CANVAS_DROP_ID })
+
+  return (
+    <section
+      ref={setNodeRef}
+      className={clsx(
+        'min-h-0 overflow-y-auto rounded-xl border border-gray-200 bg-white p-4',
+        isOver && 'border-indigo-400 ring-2 ring-indigo-100'
+      )}
+    >
+      <div className="mb-4 flex items-center justify-between">
+        <div>
+          <h4 className="text-sm font-semibold text-gray-900">Question Canvas</h4>
+          <p className="text-xs text-gray-500">Drop blocks here, then reorder and configure.</p>
+        </div>
+      </div>
+
+      {draft.questions.length === 0 ? (
+        <div className="rounded-xl border-2 border-dashed border-gray-200 bg-gray-50 p-10 text-center text-sm text-gray-500">
+          Drag question types from the left panel into this canvas.
+        </div>
+      ) : (
+        <SortableContext items={draft.questions.map((question) => question.id)} strategy={verticalListSortingStrategy}>
+          <div className="space-y-3">
+            {draft.questions.map((question, index) => (
+              <SortableQuestionCard
+                key={question.id}
+                question={question}
+                index={index}
+                onTypeChange={onTypeChange}
+                onPromptChange={onPromptChange}
+                onPointsChange={onPointsChange}
+                onRemove={onRemove}
+                onChoiceChange={onChoiceChange}
+                onAddChoice={onAddChoice}
+                onRemoveChoice={onRemoveChoice}
+                onToggleCorrectChoice={onToggleCorrectChoice}
+                onTrueFalseChange={onTrueFalseChange}
+                onBlankChange={onBlankChange}
+                onAddBlank={onAddBlank}
+                onRemoveBlank={onRemoveBlank}
+                onSampleAnswerChange={onSampleAnswerChange}
+              />
+            ))}
+          </div>
+        </SortableContext>
+      )}
+    </section>
+  )
+}
+
+export default AssessmentBuilderTab

--- a/app/src/pages/AssignedSubjects/components/AssessmentBuilderTab.tsx
+++ b/app/src/pages/AssignedSubjects/components/AssessmentBuilderTab.tsx
@@ -18,6 +18,7 @@ import {
   LightBulbIcon,
   ListBulletIcon,
 } from '@heroicons/react/24/outline'
+import { toast } from 'react-hot-toast'
 import {
   DndContext,
   DragOverlay,
@@ -54,6 +55,7 @@ import { Button } from '@/components/button'
 import { Input } from '@/components/input'
 import { Badge } from '@/components/badge'
 import { Switch } from '@/components/switch'
+import { Select } from '@/components/select'
 
 interface AssessmentBuilderTabProps {
   subjectId: string
@@ -166,6 +168,26 @@ const QUESTION_TYPE_LABELS: Record<AssessmentQuestionType, string> = {
   short_answer: 'Short Answer',
   essay: 'Essay',
 }
+
+const QUESTION_TYPE_SELECT_OPTIONS = QUESTION_TYPE_OPTIONS.map((option) => ({
+  value: option.type,
+  label: option.label,
+}))
+
+const ASSESSMENT_TYPE_SELECT_OPTIONS = TYPE_OPTIONS.map((option) => ({
+  value: option.id,
+  label: option.label,
+}))
+
+const QUARTER_SELECT_OPTIONS = ['1', '2', '3', '4'].map((quarter) => ({
+  value: quarter,
+  label: `Q${quarter}`,
+}))
+
+const STATUS_SELECT_OPTIONS: Array<{ value: AssessmentPublishStatus; label: string }> = [
+  { value: 'draft', label: 'Draft' },
+  { value: 'published', label: 'Published' },
+]
 
 const getTypeOption = (type: AssessmentMethodType) =>
   TYPE_OPTIONS.find((option) => option.id === type) ?? TYPE_OPTIONS[0]
@@ -398,17 +420,12 @@ const SortableQuestionCard: React.FC<SortableQuestionCardProps> = ({
         <div className="flex items-center gap-2">
           <div className="w-40">
             <label className="mb-1 block text-xs font-medium text-gray-600">Type</label>
-            <select
-              className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm"
+            <Select
               value={question.type}
               onChange={(event) => onTypeChange(question.id, event.target.value as AssessmentQuestionType)}
-            >
-              {QUESTION_TYPE_OPTIONS.map((option) => (
-                <option key={option.type} value={option.type}>
-                  {option.label}
-                </option>
-              ))}
-            </select>
+              options={QUESTION_TYPE_SELECT_OPTIONS}
+              className="w-full"
+            />
           </div>
           <div className="w-24">
             <label className="mb-1 block text-xs font-medium text-gray-600">Points</label>
@@ -587,22 +604,37 @@ export const AssessmentBuilderTab: React.FC<AssessmentBuilderTabProps> = ({ subj
     enabled: !!subjectId,
   })
 
+  const labelForType = (type: AssessmentMethodType) =>
+    TYPE_OPTIONS.find((option) => option.id === type)?.label ?? 'Assessment'
+  const messageFromError = (error: unknown, fallback: string) =>
+    (error as any)?.response?.data?.message ||
+    (error as any)?.message ||
+    fallback
+
   const saveCreateMutation = useMutation({
     mutationFn: (payload: AssessmentMethodInput) => assessmentMethodService.create(payload),
-    onSuccess: () => {
+    onSuccess: (_, payload) => {
+      toast.success(`${labelForType(payload.type)} saved successfully!`)
       queryClient.invalidateQueries({ queryKey: ['assessment-methods', subjectId] })
       setBuilderOpen(false)
       setDraft(null)
+    },
+    onError: (error, payload) => {
+      toast.error(messageFromError(error, `Failed to save ${labelForType(payload.type)}.`))
     },
   })
 
   const saveUpdateMutation = useMutation({
     mutationFn: ({ id, payload }: { id: string; payload: AssessmentMethodInput }) =>
       assessmentMethodService.update(id, payload),
-    onSuccess: () => {
+    onSuccess: (_, variables) => {
+      toast.success(`${labelForType(variables.payload.type)} updated successfully!`)
       queryClient.invalidateQueries({ queryKey: ['assessment-methods', subjectId] })
       setBuilderOpen(false)
       setDraft(null)
+    },
+    onError: (error, variables) => {
+      toast.error(messageFromError(error, `Failed to update ${labelForType(variables.payload.type)}.`))
     },
   })
 
@@ -1092,8 +1124,7 @@ export const AssessmentBuilderTab: React.FC<AssessmentBuilderTabProps> = ({ subj
                   <div className="mt-4 space-y-4">
                     <div>
                       <label className="mb-1 block text-xs font-medium text-gray-600">Assessment Type</label>
-                      <select
-                        className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm"
+                      <Select
                         value={draft.type}
                         onChange={(event) => {
                           const nextType = event.target.value as AssessmentMethodType
@@ -1103,13 +1134,9 @@ export const AssessmentBuilderTab: React.FC<AssessmentBuilderTabProps> = ({ subj
                             rules: { ...DEFAULT_RULES_BY_TYPE[nextType] },
                           }))
                         }}
-                      >
-                        {TYPE_OPTIONS.map((option) => (
-                          <option key={option.id} value={option.id}>
-                            {option.label}
-                          </option>
-                        ))}
-                      </select>
+                        options={ASSESSMENT_TYPE_SELECT_OPTIONS}
+                        className="w-full"
+                      />
                     </div>
 
                     <Input
@@ -1136,24 +1163,18 @@ export const AssessmentBuilderTab: React.FC<AssessmentBuilderTabProps> = ({ subj
                     <div className="grid grid-cols-2 gap-2">
                       <div>
                         <label className="mb-1 block text-xs font-medium text-gray-600">Quarter</label>
-                        <select
-                          className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm"
+                        <Select
                           value={draft.quarter}
                           onChange={(event) =>
                             updateDraft((current) => ({ ...current, quarter: event.target.value }))
                           }
-                        >
-                          {['1', '2', '3', '4'].map((quarter) => (
-                            <option key={quarter} value={quarter}>
-                              Q{quarter}
-                            </option>
-                          ))}
-                        </select>
+                          options={QUARTER_SELECT_OPTIONS}
+                          className="w-full"
+                        />
                       </div>
                       <div>
                         <label className="mb-1 block text-xs font-medium text-gray-600">Status</label>
-                        <select
-                          className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm"
+                        <Select
                           value={draft.status}
                           onChange={(event) =>
                             updateDraft((current) => ({
@@ -1161,10 +1182,9 @@ export const AssessmentBuilderTab: React.FC<AssessmentBuilderTabProps> = ({ subj
                               status: event.target.value as AssessmentPublishStatus,
                             }))
                           }
-                        >
-                          <option value="draft">Draft</option>
-                          <option value="published">Published</option>
-                        </select>
+                          options={STATUS_SELECT_OPTIONS}
+                          className="w-full"
+                        />
                       </div>
                     </div>
 

--- a/app/src/pages/AssignedSubjects/components/AssessmentBuilderTab.tsx
+++ b/app/src/pages/AssignedSubjects/components/AssessmentBuilderTab.tsx
@@ -613,11 +613,18 @@ export const AssessmentBuilderTab: React.FC<AssessmentBuilderTabProps> = ({ subj
 
   const saveCreateMutation = useMutation({
     mutationFn: (payload: AssessmentMethodInput) => assessmentMethodService.create(payload),
-    onSuccess: (_, payload) => {
-      toast.success(`${labelForType(payload.type)} saved successfully!`)
+    onSuccess: (response, payload) => {
+      const createdId = (response as any)?.data?.id ?? (response as any)?.id
+      setDraft((current) =>
+        current
+          ? {
+              ...current,
+              id: createdId ?? current.id,
+            }
+          : current
+      )
+      toast.success(`${labelForType(payload.type)} saved successfully! You can continue editing.`)
       queryClient.invalidateQueries({ queryKey: ['assessment-methods', subjectId] })
-      setBuilderOpen(false)
-      setDraft(null)
     },
     onError: (error, payload) => {
       toast.error(messageFromError(error, `Failed to save ${labelForType(payload.type)}.`))
@@ -628,10 +635,8 @@ export const AssessmentBuilderTab: React.FC<AssessmentBuilderTabProps> = ({ subj
     mutationFn: ({ id, payload }: { id: string; payload: AssessmentMethodInput }) =>
       assessmentMethodService.update(id, payload),
     onSuccess: (_, variables) => {
-      toast.success(`${labelForType(variables.payload.type)} updated successfully!`)
+      toast.success(`${labelForType(variables.payload.type)} updated successfully! You can continue editing.`)
       queryClient.invalidateQueries({ queryKey: ['assessment-methods', subjectId] })
-      setBuilderOpen(false)
-      setDraft(null)
     },
     onError: (error, variables) => {
       toast.error(messageFromError(error, `Failed to update ${labelForType(variables.payload.type)}.`))

--- a/app/src/pages/AssignedSubjects/components/AssessmentBuilderTab.tsx
+++ b/app/src/pages/AssignedSubjects/components/AssessmentBuilderTab.tsx
@@ -10,6 +10,13 @@ import {
   DocumentTextIcon,
   CalendarDaysIcon,
   ClockIcon,
+  AcademicCapIcon,
+  PencilSquareIcon,
+  BookOpenIcon,
+  CheckCircleIcon,
+  ExclamationTriangleIcon,
+  LightBulbIcon,
+  ListBulletIcon,
 } from '@heroicons/react/24/outline'
 import {
   DndContext,
@@ -69,26 +76,86 @@ interface BuilderDraft {
   questions: AssessmentMethodQuestion[]
 }
 
+type IconType = React.ComponentType<React.SVGProps<SVGSVGElement>>
+
 const CANVAS_DROP_ID = 'assessment-method-question-canvas'
 const PALETTE_PREFIX = 'assessment-palette::'
 
-const TYPE_OPTIONS: Array<{ id: AssessmentMethodType; label: string }> = [
-  { id: 'quiz', label: 'Quiz' },
-  { id: 'assignment', label: 'Assignment' },
-  { id: 'exam', label: 'Exam' },
+const TYPE_OPTIONS: Array<{
+  id: AssessmentMethodType
+  label: string
+  icon: IconType
+  accentClass: string
+}> = [
+  {
+    id: 'quiz',
+    label: 'Quiz',
+    icon: AcademicCapIcon,
+    accentClass: 'text-indigo-700 bg-indigo-100 border-indigo-200',
+  },
+  {
+    id: 'assignment',
+    label: 'Assignment',
+    icon: PencilSquareIcon,
+    accentClass: 'text-emerald-700 bg-emerald-100 border-emerald-200',
+  },
+  {
+    id: 'exam',
+    label: 'Exam',
+    icon: BookOpenIcon,
+    accentClass: 'text-violet-700 bg-violet-100 border-violet-200',
+  },
 ]
 
 const QUESTION_TYPE_OPTIONS: Array<{
   type: AssessmentQuestionType
   label: string
   hint: string
+  icon: IconType
+  accentClass: string
 }> = [
-  { type: 'single_choice', label: 'Multiple Choice', hint: 'One correct option' },
-  { type: 'multiple_choice', label: 'Multiple Response', hint: 'Many correct options' },
-  { type: 'true_false', label: 'True / False', hint: 'Binary answer' },
-  { type: 'fill_in_the_blanks', label: 'Fill in the Blanks', hint: 'Ordered blank answers' },
-  { type: 'short_answer', label: 'Short Answer', hint: 'Short text response' },
-  { type: 'essay', label: 'Essay', hint: 'Long-form response' },
+  {
+    type: 'single_choice',
+    label: 'Multiple Choice',
+    hint: 'One correct option',
+    icon: ListBulletIcon,
+    accentClass: 'text-indigo-700 bg-indigo-100 border-indigo-200',
+  },
+  {
+    type: 'multiple_choice',
+    label: 'Multiple Response',
+    hint: 'Many correct options',
+    icon: CheckCircleIcon,
+    accentClass: 'text-sky-700 bg-sky-100 border-sky-200',
+  },
+  {
+    type: 'true_false',
+    label: 'True / False',
+    hint: 'Binary answer',
+    icon: ExclamationTriangleIcon,
+    accentClass: 'text-amber-700 bg-amber-100 border-amber-200',
+  },
+  {
+    type: 'fill_in_the_blanks',
+    label: 'Fill in the Blanks',
+    hint: 'Ordered blank answers',
+    icon: DocumentTextIcon,
+    accentClass: 'text-violet-700 bg-violet-100 border-violet-200',
+  },
+  {
+    type: 'short_answer',
+    label: 'Short Answer',
+    hint: 'Short text response',
+    icon: PencilSquareIcon,
+    accentClass: 'text-emerald-700 bg-emerald-100 border-emerald-200',
+  },
+  {
+    type: 'essay',
+    label: 'Essay',
+    hint: 'Long-form response',
+    icon: BookOpenIcon,
+    accentClass: 'text-rose-700 bg-rose-100 border-rose-200',
+  },
 ]
 
 const QUESTION_TYPE_LABELS: Record<AssessmentQuestionType, string> = {
@@ -99,6 +166,12 @@ const QUESTION_TYPE_LABELS: Record<AssessmentQuestionType, string> = {
   short_answer: 'Short Answer',
   essay: 'Essay',
 }
+
+const getTypeOption = (type: AssessmentMethodType) =>
+  TYPE_OPTIONS.find((option) => option.id === type) ?? TYPE_OPTIONS[0]
+
+const getQuestionTypeOption = (type: AssessmentQuestionType) =>
+  QUESTION_TYPE_OPTIONS.find((option) => option.type === type) ?? QUESTION_TYPE_OPTIONS[0]
 
 const toDateTimeLocal = (value: string | null | undefined): string => {
   if (!value) return ''
@@ -215,7 +288,9 @@ const PaletteCard: React.FC<{
   type: AssessmentQuestionType
   label: string
   hint: string
-}> = ({ type, label, hint }) => {
+  icon: IconType
+  accentClass: string
+}> = ({ type, label, hint, icon: Icon, accentClass }) => {
   const { attributes, listeners, setNodeRef, transform, isDragging } = useDraggable({
     id: paletteCardId(type),
   })
@@ -232,8 +307,20 @@ const PaletteCard: React.FC<{
       {...attributes}
       {...listeners}
     >
-      <p className="text-sm font-semibold text-gray-900">{label}</p>
-      <p className="mt-1 text-xs text-gray-500">{hint}</p>
+      <div className="flex items-start justify-between gap-2">
+        <div className="flex items-start gap-3">
+          <div className={clsx('mt-0.5 rounded-lg border p-1.5', accentClass)}>
+            <Icon className="h-4 w-4" />
+          </div>
+          <div>
+            <p className="text-sm font-semibold text-gray-900">{label}</p>
+            <p className="mt-1 text-xs text-gray-500">{hint}</p>
+          </div>
+        </div>
+        <div className="rounded-md border border-gray-200 bg-gray-50 p-1 text-gray-400">
+          <Bars3Icon className="h-3.5 w-3.5" />
+        </div>
+      </div>
     </button>
   )
 }
@@ -276,6 +363,8 @@ const SortableQuestionCard: React.FC<SortableQuestionCardProps> = ({
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: question.id,
   })
+  const questionMeta = getQuestionTypeOption(question.type)
+  const QuestionIcon = questionMeta.icon
 
   return (
     <div
@@ -301,7 +390,10 @@ const SortableQuestionCard: React.FC<SortableQuestionCardProps> = ({
             <Bars3Icon className="h-4 w-4" />
           </button>
           <span className="text-sm font-semibold text-gray-900">Question {index + 1}</span>
-          <Badge color="indigo">{QUESTION_TYPE_LABELS[question.type]}</Badge>
+          <Badge color="indigo">
+            <QuestionIcon className="h-3.5 w-3.5" />
+            {QUESTION_TYPE_LABELS[question.type]}
+          </Badge>
         </div>
         <div className="flex items-center gap-2">
           <div className="w-40">
@@ -687,7 +779,13 @@ export const AssessmentBuilderTab: React.FC<AssessmentBuilderTabProps> = ({ subj
     <div className="space-y-4">
       {!firstEcrId && (
         <div className="rounded-xl border border-amber-200 bg-amber-50 p-3 text-sm text-amber-700">
+          <div className="mb-1 inline-flex items-center gap-1 font-semibold">
+            <ExclamationTriangleIcon className="h-4 w-4" />
+            Setup required
+          </div>
+          <div>
           Create your <strong>Components of Summative Assessment</strong> first so assessment methods can be attached to an ECR component.
+          </div>
         </div>
       )}
 
@@ -699,12 +797,13 @@ export const AssessmentBuilderTab: React.FC<AssessmentBuilderTabProps> = ({ subj
               type="button"
               onClick={() => setActiveType(option.id)}
               className={clsx(
-                'rounded-lg px-4 py-2 text-sm font-medium transition',
+                'inline-flex items-center gap-2 rounded-lg border px-4 py-2 text-sm font-medium transition',
                 activeType === option.id
-                  ? 'bg-indigo-600 text-white'
-                  : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
+                  ? 'border-indigo-600 bg-indigo-600 text-white'
+                  : 'border-transparent bg-gray-100 text-gray-700 hover:bg-gray-200'
               )}
             >
+              <option.icon className="h-4 w-4" />
               {option.label}
             </button>
           ))}
@@ -721,15 +820,21 @@ export const AssessmentBuilderTab: React.FC<AssessmentBuilderTabProps> = ({ subj
       </div>
 
       {isLoading ? (
-        <div className="py-10 text-center text-sm text-gray-500">Loading assessment methods...</div>
+        <div className="py-10 text-center text-sm text-gray-500">
+          <ClockIcon className="mx-auto mb-2 h-5 w-5 animate-pulse text-gray-400" />
+          Loading assessment methods...
+        </div>
       ) : methods.length === 0 ? (
         <div className="rounded-xl border-2 border-dashed border-gray-200 bg-gray-50 p-10 text-center text-sm text-gray-500">
+          {React.createElement(getTypeOption(activeType).icon, { className: 'mx-auto mb-2 h-6 w-6 text-gray-400' })}
           No {activeType}s yet. Create one and build questions with drag and drop.
         </div>
       ) : (
         <ul className="space-y-3">
           {methods.map((method) => {
             const points = method.questions.reduce((sum, question) => sum + question.points, 0)
+            const typeMeta = getTypeOption(method.type)
+            const TypeIcon = typeMeta.icon
             return (
               <li
                 key={method.id}
@@ -738,9 +843,21 @@ export const AssessmentBuilderTab: React.FC<AssessmentBuilderTabProps> = ({ subj
                 <div className="flex items-start justify-between gap-4">
                   <div className="min-w-0 flex-1">
                     <div className="flex flex-wrap items-center gap-2">
+                      <div className={clsx('rounded-lg border p-1.5', typeMeta.accentClass)}>
+                        <TypeIcon className="h-4 w-4" />
+                      </div>
                       <h4 className="truncate font-semibold text-gray-900">{method.title}</h4>
                       <Badge color={method.status === 'published' ? 'green' : 'amber'}>
+                        {method.status === 'published' ? (
+                          <CheckCircleIcon className="h-3.5 w-3.5" />
+                        ) : (
+                          <PencilSquareIcon className="h-3.5 w-3.5" />
+                        )}
                         {method.status === 'published' ? 'Published' : 'Draft'}
+                      </Badge>
+                      <Badge color="blue">
+                        <TypeIcon className="h-3.5 w-3.5" />
+                        {typeMeta.label}
                       </Badge>
                       <Badge color="zinc">Q{method.quarter}</Badge>
                     </div>
@@ -795,14 +912,41 @@ export const AssessmentBuilderTab: React.FC<AssessmentBuilderTabProps> = ({ subj
       {builderOpen && draft && (
         <div className="fixed inset-0 z-50 bg-black/50">
           <div className="absolute inset-0 flex flex-col bg-white">
-            <header className="flex items-center justify-between border-b border-gray-200 px-6 py-4">
+            <header className="flex flex-wrap items-center justify-between gap-3 border-b border-gray-200 bg-gradient-to-r from-indigo-50 via-white to-white px-6 py-4">
               <div>
-                <h3 className="text-lg font-semibold text-gray-900">
-                  {draft.id ? 'Edit' : 'Create'} {draft.type.charAt(0).toUpperCase() + draft.type.slice(1)}
-                </h3>
-                <p className="text-sm text-gray-500">
-                  Tutor-style builder: drag question types into canvas, then configure details.
+                <div className="flex flex-wrap items-center gap-2">
+                  <div className={clsx('rounded-lg border p-1.5', getTypeOption(draft.type).accentClass)}>
+                    {React.createElement(getTypeOption(draft.type).icon, { className: 'h-4 w-4' })}
+                  </div>
+                  <h3 className="text-lg font-semibold text-gray-900">
+                    {draft.id ? 'Edit' : 'Create'} {draft.type.charAt(0).toUpperCase() + draft.type.slice(1)}
+                  </h3>
+                  <Badge color={draft.status === 'published' ? 'green' : 'amber'}>
+                    {draft.status === 'published' ? (
+                      <CheckCircleIcon className="h-3.5 w-3.5" />
+                    ) : (
+                      <PencilSquareIcon className="h-3.5 w-3.5" />
+                    )}
+                    {draft.status === 'published' ? 'Published' : 'Draft'}
+                  </Badge>
+                </div>
+                <p className="mt-1 text-sm text-gray-500">
+                  Drag question types into the canvas, then configure scoring and assessment rules.
                 </p>
+                <div className="mt-2 flex flex-wrap items-center gap-2">
+                  <span className="inline-flex items-center gap-1 rounded-full border border-indigo-200 bg-indigo-50 px-2.5 py-1 text-xs font-medium text-indigo-700">
+                    <DocumentTextIcon className="h-3.5 w-3.5" />
+                    {draft.questions.length} question(s)
+                  </span>
+                  <span className="inline-flex items-center gap-1 rounded-full border border-sky-200 bg-sky-50 px-2.5 py-1 text-xs font-medium text-sky-700">
+                    <ClockIcon className="h-3.5 w-3.5" />
+                    {totalPoints} point(s)
+                  </span>
+                  <span className="inline-flex items-center gap-1 rounded-full border border-emerald-200 bg-emerald-50 px-2.5 py-1 text-xs font-medium text-emerald-700">
+                    <CheckCircleIcon className="h-3.5 w-3.5" />
+                    {validationErrors.length === 0 ? 'Ready to save' : `${validationErrors.length} issue(s)`}
+                  </span>
+                </div>
               </div>
               <div className="flex items-center gap-2">
                 <Button type="button" variant="outline" onClick={closeBuilder}>
@@ -829,7 +973,12 @@ export const AssessmentBuilderTab: React.FC<AssessmentBuilderTabProps> = ({ subj
             >
               <div className="grid min-h-0 flex-1 grid-cols-1 gap-4 bg-gray-50 p-4 lg:grid-cols-[18rem_minmax(0,1fr)_22rem]">
                 <aside className="min-h-0 overflow-y-auto rounded-xl border border-gray-200 bg-white p-4">
-                  <h4 className="text-sm font-semibold text-gray-900">Question Types</h4>
+                  <div className="flex items-center gap-2">
+                    <div className="rounded-lg border border-indigo-200 bg-indigo-50 p-1.5 text-indigo-700">
+                      <LightBulbIcon className="h-4 w-4" />
+                    </div>
+                    <h4 className="text-sm font-semibold text-gray-900">Question Types</h4>
+                  </div>
                   <p className="mt-1 text-xs text-gray-500">
                     Drag any block into the canvas.
                   </p>
@@ -840,6 +989,8 @@ export const AssessmentBuilderTab: React.FC<AssessmentBuilderTabProps> = ({ subj
                         type={option.type}
                         label={option.label}
                         hint={option.hint}
+                        icon={option.icon}
+                        accentClass={option.accentClass}
                       />
                     ))}
                   </div>
@@ -932,7 +1083,12 @@ export const AssessmentBuilderTab: React.FC<AssessmentBuilderTabProps> = ({ subj
                 />
 
                 <aside className="min-h-0 overflow-y-auto rounded-xl border border-gray-200 bg-white p-4">
-                  <h4 className="text-sm font-semibold text-gray-900">Assessment Settings</h4>
+                  <div className="flex items-center gap-2">
+                    <div className="rounded-lg border border-emerald-200 bg-emerald-50 p-1.5 text-emerald-700">
+                      <PencilSquareIcon className="h-4 w-4" />
+                    </div>
+                    <h4 className="text-sm font-semibold text-gray-900">Assessment Settings</h4>
+                  </div>
                   <div className="mt-4 space-y-4">
                     <div>
                       <label className="mb-1 block text-xs font-medium text-gray-600">Assessment Type</label>
@@ -1013,7 +1169,10 @@ export const AssessmentBuilderTab: React.FC<AssessmentBuilderTabProps> = ({ subj
                     </div>
 
                     <div className="rounded-lg border border-gray-200 p-3">
-                      <p className="text-xs font-semibold uppercase tracking-wide text-gray-500">Schedule</p>
+                      <p className="inline-flex items-center gap-1 text-xs font-semibold uppercase tracking-wide text-gray-500">
+                        <CalendarDaysIcon className="h-3.5 w-3.5" />
+                        Schedule
+                      </p>
                       <div className="mt-3 space-y-2">
                         <div>
                           <label className="mb-1 block text-xs font-medium text-gray-600">Scheduled Date</label>
@@ -1072,7 +1231,10 @@ export const AssessmentBuilderTab: React.FC<AssessmentBuilderTabProps> = ({ subj
                     </div>
 
                     <div className="rounded-lg border border-gray-200 p-3">
-                      <p className="text-xs font-semibold uppercase tracking-wide text-gray-500">Rules</p>
+                      <p className="inline-flex items-center gap-1 text-xs font-semibold uppercase tracking-wide text-gray-500">
+                        <ClockIcon className="h-3.5 w-3.5" />
+                        Rules
+                      </p>
                       <div className="mt-3 space-y-2">
                         <div>
                           <label className="mb-1 block text-xs font-medium text-gray-600">Max Attempts</label>
@@ -1149,7 +1311,10 @@ export const AssessmentBuilderTab: React.FC<AssessmentBuilderTabProps> = ({ subj
                     </div>
 
                     <div className="rounded-lg border border-indigo-100 bg-indigo-50 p-3">
-                      <p className="text-xs font-semibold uppercase tracking-wide text-indigo-700">Summary</p>
+                      <p className="inline-flex items-center gap-1 text-xs font-semibold uppercase tracking-wide text-indigo-700">
+                        <DocumentTextIcon className="h-3.5 w-3.5" />
+                        Summary
+                      </p>
                       <p className="mt-1 text-sm text-indigo-800">{draft.questions.length} question(s)</p>
                       <p className="text-sm text-indigo-800">{totalPoints} total point(s)</p>
                     </div>
@@ -1159,7 +1324,8 @@ export const AssessmentBuilderTab: React.FC<AssessmentBuilderTabProps> = ({ subj
 
               <DragOverlay>
                 {currentDragType ? (
-                  <div className="rounded-xl border border-indigo-300 bg-indigo-50 px-3 py-2 text-sm font-semibold text-indigo-700 shadow">
+                  <div className="inline-flex items-center gap-2 rounded-xl border border-indigo-300 bg-indigo-50 px-3 py-2 text-sm font-semibold text-indigo-700 shadow">
+                    {React.createElement(getQuestionTypeOption(currentDragType).icon, { className: 'h-4 w-4' })}
                     {QUESTION_TYPE_LABELS[currentDragType]}
                   </div>
                 ) : null}
@@ -1168,6 +1334,10 @@ export const AssessmentBuilderTab: React.FC<AssessmentBuilderTabProps> = ({ subj
 
             {validationErrors.length > 0 && (
               <div className="border-t border-red-100 bg-red-50 px-6 py-3">
+                <div className="mb-1 inline-flex items-center gap-1 text-xs font-semibold uppercase tracking-wide text-red-700">
+                  <ExclamationTriangleIcon className="h-3.5 w-3.5" />
+                  Validation Issues
+                </div>
                 <ul className="list-disc space-y-1 pl-5 text-xs text-red-700">
                   {validationErrors.slice(0, 4).map((error) => (
                     <li key={error}>{error}</li>
@@ -1226,13 +1396,19 @@ const CanvasPanel: React.FC<{
     >
       <div className="mb-4 flex items-center justify-between">
         <div>
-          <h4 className="text-sm font-semibold text-gray-900">Question Canvas</h4>
+          <h4 className="inline-flex items-center gap-2 text-sm font-semibold text-gray-900">
+            <div className="rounded-lg border border-sky-200 bg-sky-50 p-1 text-sky-700">
+              <DocumentTextIcon className="h-3.5 w-3.5" />
+            </div>
+            Question Canvas
+          </h4>
           <p className="text-xs text-gray-500">Drop blocks here, then reorder and configure.</p>
         </div>
       </div>
 
       {draft.questions.length === 0 ? (
         <div className="rounded-xl border-2 border-dashed border-gray-200 bg-gray-50 p-10 text-center text-sm text-gray-500">
+          <DocumentTextIcon className="mx-auto mb-2 h-6 w-6 text-gray-400" />
           Drag question types from the left panel into this canvas.
         </div>
       ) : (

--- a/app/src/pages/MyAssessments/MyAssessments.tsx
+++ b/app/src/pages/MyAssessments/MyAssessments.tsx
@@ -1,10 +1,23 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { Link } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
-import { DocumentTextIcon, PlayIcon, CheckCircleIcon, ClockIcon } from '@heroicons/react/24/outline';
+import {
+  DocumentTextIcon,
+  PlayIcon,
+  CheckCircleIcon,
+  ClockIcon,
+  BookOpenIcon,
+  ChevronRightIcon,
+} from '@heroicons/react/24/outline';
 import { studentAssessmentService, type StudentAssessmentItem } from '@/services/studentAssessmentService';
-import { Button } from '@/components/button';
 import { Badge } from '@/components/badge';
+
+interface SubjectAssessmentGroup {
+  subjectTitle: string;
+  assessments: StudentAssessmentItem[];
+}
+
+const toDateSort = (value?: string | null) => (value ? new Date(value).getTime() : Number.MAX_SAFE_INTEGER);
 
 export const MyAssessments: React.FC = () => {
   const { data, isLoading, error } = useQuery({
@@ -16,9 +29,36 @@ export const MyAssessments: React.FC = () => {
   const items = (data?.data ?? []) as StudentAssessmentItem[];
   const forbidden = error && (error as any)?.response?.status === 403;
 
+  const publishedItems = useMemo(
+    () => items.filter((item) => (item.status ?? 'published') === 'published'),
+    [items]
+  );
+
+  const groups = useMemo<SubjectAssessmentGroup[]>(() => {
+    const bySubject = new Map<string, StudentAssessmentItem[]>();
+    for (const item of publishedItems) {
+      const key = item.subject_title?.trim() || 'Unassigned Subject';
+      if (!bySubject.has(key)) bySubject.set(key, []);
+      bySubject.get(key)!.push(item);
+    }
+
+    return Array.from(bySubject.entries())
+      .map(([subjectTitle, assessments]) => ({
+        subjectTitle,
+        assessments: [...assessments].sort((a, b) => {
+          const dueDiff = toDateSort(a.due_at) - toDateSort(b.due_at);
+          if (dueDiff !== 0) return dueDiff;
+          const scheduledDiff = toDateSort(a.scheduled_date) - toDateSort(b.scheduled_date);
+          if (scheduledDiff !== 0) return scheduledDiff;
+          return a.title.localeCompare(b.title);
+        }),
+      }))
+      .sort((a, b) => a.subjectTitle.localeCompare(b.subjectTitle));
+  }, [publishedItems]);
+
   if (forbidden) {
     return (
-      <div className="max-w-3xl mx-auto p-6">
+      <div className="max-w-5xl mx-auto p-6">
         <div className="bg-amber-50 border border-amber-200 rounded-xl p-6 text-center">
           <DocumentTextIcon className="w-12 h-12 text-amber-600 mx-auto mb-3" />
           <h2 className="text-lg font-semibold text-amber-900 mb-2">Not linked to a student account</h2>
@@ -32,7 +72,7 @@ export const MyAssessments: React.FC = () => {
 
   if (isLoading) {
     return (
-      <div className="max-w-3xl mx-auto p-6">
+      <div className="max-w-5xl mx-auto p-6">
         <div className="flex items-center justify-center py-12">
           <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-indigo-600" />
           <span className="ml-3 text-gray-600">Loading assessments...</span>
@@ -43,7 +83,7 @@ export const MyAssessments: React.FC = () => {
 
   if (error) {
     return (
-      <div className="max-w-3xl mx-auto p-6">
+      <div className="max-w-5xl mx-auto p-6">
         <div className="bg-red-50 border border-red-200 rounded-xl p-6 text-center">
           <p className="text-red-800">Failed to load assessments. Please try again.</p>
         </div>
@@ -52,72 +92,106 @@ export const MyAssessments: React.FC = () => {
   }
 
   return (
-    <div className="max-w-3xl mx-auto p-6 space-y-6">
+    <div className="max-w-5xl mx-auto p-6 space-y-6">
       <div>
         <h1 className="text-2xl font-bold text-gray-900">My Assessments</h1>
-        <p className="text-gray-600 mt-1">Quizzes, assignments, and exams you can take. Your score is shown after you submit.</p>
+        <p className="text-gray-600 mt-1">
+          Published quizzes, assignments, and exams grouped by subject. Click any item to answer.
+        </p>
       </div>
 
-      {items.length === 0 ? (
+      {publishedItems.length === 0 ? (
         <div className="bg-gray-50 border-2 border-dashed border-gray-200 rounded-xl p-12 text-center text-gray-500">
           <DocumentTextIcon className="w-12 h-12 mx-auto mb-3 text-gray-400" />
-          <p>No assessments assigned yet.</p>
+          <p>No published assessments yet.</p>
         </div>
       ) : (
-        <ul className="space-y-3">
-          {items.map((item) => (
-            <li
-              key={item.id}
-              className="bg-white border border-gray-200 rounded-xl p-4 shadow-sm hover:border-indigo-200 transition-colors"
-            >
-              <div className="flex items-start justify-between gap-4">
-                <div className="flex-1 min-w-0">
-                  <div className="flex items-center gap-2 flex-wrap">
-                    <span className="font-semibold text-gray-900">{item.title}</span>
-                    <Badge color="zinc">{item.type}</Badge>
-                    {item.quarter && <Badge color="zinc">Q{item.quarter}</Badge>}
-                    {item.attempt_status === 'submitted' && (
-                      <span className="inline-flex items-center gap-1 text-sm text-green-700">
+        <div className="space-y-4">
+          {groups.map((group) => (
+            <section key={group.subjectTitle} className="bg-white border border-gray-200 rounded-xl shadow-sm">
+              <div className="px-4 py-3 border-b border-gray-100 flex items-center justify-between gap-3">
+                <div className="flex items-center gap-2 min-w-0">
+                  <div className="w-8 h-8 rounded-lg bg-indigo-100 text-indigo-700 flex items-center justify-center">
+                    <BookOpenIcon className="w-4 h-4" />
+                  </div>
+                  <h2 className="text-sm sm:text-base font-semibold text-gray-900 truncate">{group.subjectTitle}</h2>
+                </div>
+                <Badge color="zinc">{group.assessments.length} item(s)</Badge>
+              </div>
+
+              <ul className="divide-y divide-gray-100">
+                {group.assessments.map((item) => {
+                  const canOpen = item.has_questions || item.attempt_status === 'submitted' || item.attempt_status === 'in_progress';
+                  const ctaLabel =
+                    item.attempt_status === 'submitted'
+                      ? 'View result'
+                      : item.attempt_status === 'in_progress'
+                        ? 'Continue'
+                        : 'Take assessment';
+
+                  const statusPill =
+                    item.attempt_status === 'submitted' ? (
+                      <span className="inline-flex items-center gap-1 text-xs font-medium text-green-700">
                         <CheckCircleIcon className="w-4 h-4" />
                         Submitted
                       </span>
-                    )}
-                    {item.attempt_status === 'in_progress' && (
-                      <span className="inline-flex items-center gap-1 text-sm text-amber-700">
+                    ) : item.attempt_status === 'in_progress' ? (
+                      <span className="inline-flex items-center gap-1 text-xs font-medium text-amber-700">
                         <ClockIcon className="w-4 h-4" />
                         In progress
                       </span>
-                    )}
-                  </div>
-                  {item.subject_title && (
-                    <p className="text-sm text-gray-500 mt-1">{item.subject_title}</p>
-                  )}
-                  {item.attempt_status === 'submitted' && item.attempt_score != null && item.attempt_max_score != null && (
-                    <p className="text-sm font-medium text-indigo-600 mt-2">
-                      Score: {item.attempt_score} / {item.attempt_max_score}
-                    </p>
-                  )}
-                </div>
-                <div className="flex-shrink-0">
-                  {item.attempt_status === 'submitted' ? (
-                    <Link to={`/my-assessments/${item.id}/take`}>
-                      <Button variant="outline" size="sm">View result</Button>
-                    </Link>
-                  ) : item.has_questions ? (
-                    <Link to={`/my-assessments/${item.id}/take`}>
-                      <Button size="sm" className="inline-flex items-center gap-1">
+                    ) : (
+                      <span className="inline-flex items-center gap-1 text-xs font-medium text-indigo-700">
                         <PlayIcon className="w-4 h-4" />
-                        {item.attempt_status === 'in_progress' ? 'Continue' : 'Take'}
-                      </Button>
-                    </Link>
-                  ) : (
-                    <span className="text-xs text-gray-500">No questions yet</span>
-                  )}
-                </div>
-              </div>
-            </li>
+                        Ready
+                      </span>
+                    );
+
+                  const content = (
+                    <div className="p-4 flex items-start justify-between gap-4 transition-colors hover:bg-indigo-50/40">
+                      <div className="min-w-0 flex-1">
+                        <div className="flex flex-wrap items-center gap-2">
+                          <p className="font-semibold text-gray-900 truncate">{item.title}</p>
+                          <Badge color="blue">{item.type}</Badge>
+                          {item.quarter && <Badge color="zinc">Q{item.quarter}</Badge>}
+                          {statusPill}
+                        </div>
+                        {item.description && (
+                          <p className="text-sm text-gray-600 mt-1 line-clamp-2">{item.description}</p>
+                        )}
+                        <div className="mt-2 flex flex-wrap items-center gap-3 text-xs text-gray-500">
+                          {item.max_score != null && <span>Max score: {item.max_score}</span>}
+                          {item.due_at && <span>Due: {new Date(item.due_at).toLocaleString()}</span>}
+                          {item.attempt_status === 'submitted' && item.attempt_score != null && item.attempt_max_score != null && (
+                            <span className="font-medium text-indigo-700">
+                              Score: {item.attempt_score} / {item.attempt_max_score}
+                            </span>
+                          )}
+                        </div>
+                      </div>
+                      <div className="flex items-center gap-1 text-indigo-700 text-sm font-medium shrink-0">
+                        {canOpen ? (
+                          <>
+                            <span>{ctaLabel}</span>
+                            <ChevronRightIcon className="w-4 h-4" />
+                          </>
+                        ) : (
+                          <span className="text-gray-400">No questions yet</span>
+                        )}
+                      </div>
+                    </div>
+                  );
+
+                  return (
+                    <li key={item.id}>
+                      {canOpen ? <Link to={`/my-assessments/${item.id}/take`}>{content}</Link> : content}
+                    </li>
+                  );
+                })}
+              </ul>
+            </section>
           ))}
-        </ul>
+        </div>
       )}
     </div>
   );

--- a/app/src/pages/MyAssessments/TakeAssessment.tsx
+++ b/app/src/pages/MyAssessments/TakeAssessment.tsx
@@ -79,6 +79,10 @@ export const TakeAssessment: React.FC = () => {
     });
   };
 
+  const handleTextAnswer = (index: number, value: string) => {
+    setAnswers((prev) => ({ ...prev, [String(index)]: value }));
+  };
+
   const handleSubmit = () => {
     submitMutation.mutate(answers);
   };
@@ -182,7 +186,7 @@ export const TakeAssessment: React.FC = () => {
                 )}
                 {type === 'single_choice' &&
                   q.choices?.map((choice, cIdx) => {
-                    const letter = choice.charAt(0).toUpperCase();
+                    const letter = String.fromCharCode(65 + cIdx);
                     const isSelected = answerVal === letter || answerVal === choice;
                     return (
                       <label
@@ -205,7 +209,7 @@ export const TakeAssessment: React.FC = () => {
                   })}
                 {type === 'multiple_choice' && (
                   q.choices?.map((choice, cIdx) => {
-                    const letter = choice.charAt(0).toUpperCase();
+                    const letter = String.fromCharCode(65 + cIdx);
                     const selectedArr = Array.isArray(answerVal) ? answerVal : answerVal ? [answerVal] : [];
                     const isSelected = selectedArr.includes(letter);
                     return (
@@ -240,6 +244,29 @@ export const TakeAssessment: React.FC = () => {
                         />
                       </div>
                     ))}
+                  </div>
+                )}
+                {type === 'short_answer' && (
+                  <div>
+                    <label className="block text-xs text-gray-500 mb-1">Your answer</label>
+                    <input
+                      type="text"
+                      value={typeof answerVal === 'string' ? answerVal : ''}
+                      onChange={(e) => handleTextAnswer(q.index, e.target.value)}
+                      className="w-full border border-gray-300 rounded-md px-3 py-2 text-sm"
+                      placeholder={q.placeholder ?? 'Write your answer'}
+                    />
+                  </div>
+                )}
+                {type === 'essay' && (
+                  <div>
+                    <label className="block text-xs text-gray-500 mb-1">Your answer</label>
+                    <textarea
+                      value={typeof answerVal === 'string' ? answerVal : ''}
+                      onChange={(e) => handleTextAnswer(q.index, e.target.value)}
+                      className="w-full min-h-32 border border-gray-300 rounded-md px-3 py-2 text-sm"
+                      placeholder={q.placeholder ?? 'Write your detailed response'}
+                    />
                   </div>
                 )}
               </div>

--- a/app/src/pages/MyAssessments/TakeAssessment.tsx
+++ b/app/src/pages/MyAssessments/TakeAssessment.tsx
@@ -52,6 +52,13 @@ export const TakeAssessment: React.FC = () => {
     }
   }, [status, questions.length, startMutation.isPending, startMutation.data]);
 
+  useEffect(() => {
+    if (alreadySubmitted && payload?.attempt) {
+      setResult({ score: payload.attempt.score ?? 0, max_score: payload.attempt.max_score ?? 0 });
+      setSubmitted(true);
+    }
+  }, [alreadySubmitted, payload?.attempt]);
+
   const handleAnswer = (index: number, value: string) => {
     setAnswers((prev) => ({ ...prev, [String(index)]: value }));
   };
@@ -100,13 +107,6 @@ export const TakeAssessment: React.FC = () => {
       </div>
     );
   }
-
-  useEffect(() => {
-    if (alreadySubmitted && payload?.attempt) {
-      setResult({ score: payload.attempt.score ?? 0, max_score: payload.attempt.max_score ?? 0 });
-      setSubmitted(true);
-    }
-  }, [alreadySubmitted, payload?.attempt]);
 
   if (submitted && result) {
     return (

--- a/app/src/services/assessmentMethodService.ts
+++ b/app/src/services/assessmentMethodService.ts
@@ -100,9 +100,16 @@ const normalizeChoiceAnswers = (value: unknown): string[] => {
   return Array.from(new Set(values.map(normalizeChoiceAnswer).filter(Boolean))).sort()
 }
 
-const mapQuestionFromItem = (
-  question: NonNullable<SubjectEcrItem['content']>['questions'][number]
-): AssessmentMethodQuestion => {
+interface RawAssessmentQuestion {
+  type?: string
+  question?: string
+  choices?: string[]
+  answer?: string | string[]
+  blanks?: string[]
+  points?: number
+}
+
+const mapQuestionFromItem = (question: RawAssessmentQuestion): AssessmentMethodQuestion => {
   const type = QUESTION_TYPE_SET.has(question.type as AssessmentQuestionType)
     ? (question.type as AssessmentQuestionType)
     : 'single_choice'

--- a/app/src/services/assessmentMethodService.ts
+++ b/app/src/services/assessmentMethodService.ts
@@ -1,0 +1,283 @@
+import { nanoid } from 'nanoid'
+import { subjectEcrItemService, type SubjectEcrItem } from './subjectEcrItemService'
+
+export type AssessmentMethodType = 'quiz' | 'assignment' | 'exam'
+export type AssessmentPublishStatus = 'draft' | 'published'
+export type AssessmentQuestionType =
+  | 'single_choice'
+  | 'multiple_choice'
+  | 'fill_in_the_blanks'
+  | 'true_false'
+  | 'short_answer'
+  | 'essay'
+
+export interface AssessmentMethodRules {
+  maxAttempts: number
+  timeLimitMinutes: number | null
+  passMark: number | null
+  randomizeQuestions: boolean
+}
+
+export interface AssessmentMethodQuestion {
+  id: string
+  type: AssessmentQuestionType
+  prompt: string
+  points: number
+  choices: string[]
+  correctAnswers: string[]
+  blanks: string[]
+  sampleAnswer: string
+}
+
+export interface AssessmentMethod {
+  id?: string
+  subjectEcrId: string
+  type: AssessmentMethodType
+  status: AssessmentPublishStatus
+  title: string
+  description: string
+  quarter: string
+  scheduledDate: string | null
+  openAt: string | null
+  closeAt: string | null
+  dueAt: string | null
+  allowLateSubmission: boolean
+  rules: AssessmentMethodRules
+  questions: AssessmentMethodQuestion[]
+  createdAt?: string
+  updatedAt?: string
+}
+
+export type AssessmentMethodInput = Omit<AssessmentMethod, 'id' | 'createdAt' | 'updatedAt'>
+
+const QUESTION_TYPE_SET = new Set<AssessmentQuestionType>([
+  'single_choice',
+  'multiple_choice',
+  'fill_in_the_blanks',
+  'true_false',
+  'short_answer',
+  'essay',
+])
+
+const DEFAULT_RULES_BY_TYPE: Record<AssessmentMethodType, AssessmentMethodRules> = {
+  quiz: {
+    maxAttempts: 3,
+    timeLimitMinutes: 30,
+    passMark: 60,
+    randomizeQuestions: false,
+  },
+  assignment: {
+    maxAttempts: 1,
+    timeLimitMinutes: null,
+    passMark: null,
+    randomizeQuestions: false,
+  },
+  exam: {
+    maxAttempts: 1,
+    timeLimitMinutes: 90,
+    passMark: 70,
+    randomizeQuestions: false,
+  },
+}
+
+const defaultChoiceList = () => ['', '', '', '']
+
+const normalizeChoiceAnswer = (value: unknown): string => {
+  const raw = String(value ?? '').trim()
+  if (!raw) return 'A'
+  if (/^[A-Za-z]$/.test(raw)) return raw.toUpperCase()
+  const maybePrefix = raw.match(/^([A-Za-z])[.)\s]/)
+  if (maybePrefix?.[1]) return maybePrefix[1].toUpperCase()
+  return raw.charAt(0).toUpperCase()
+}
+
+const normalizeChoiceAnswers = (value: unknown): string[] => {
+  const values = Array.isArray(value)
+    ? value
+    : typeof value === 'string'
+      ? value.split(',')
+      : []
+  return Array.from(new Set(values.map(normalizeChoiceAnswer).filter(Boolean))).sort()
+}
+
+const mapQuestionFromItem = (
+  question: NonNullable<SubjectEcrItem['content']>['questions'][number]
+): AssessmentMethodQuestion => {
+  const type = QUESTION_TYPE_SET.has(question.type as AssessmentQuestionType)
+    ? (question.type as AssessmentQuestionType)
+    : 'single_choice'
+
+  const baseQuestion: AssessmentMethodQuestion = {
+    id: nanoid(),
+    type,
+    prompt: question.question ?? '',
+    points: typeof question.points === 'number' ? question.points : 1,
+    choices: type === 'true_false' ? ['True', 'False'] : (question.choices ?? defaultChoiceList()),
+    correctAnswers: [],
+    blanks: [],
+    sampleAnswer: '',
+  }
+
+  if (type === 'single_choice') {
+    baseQuestion.correctAnswers = [normalizeChoiceAnswer(question.answer)]
+  } else if (type === 'multiple_choice') {
+    baseQuestion.correctAnswers = normalizeChoiceAnswers(question.answer)
+  } else if (type === 'true_false') {
+    const trueFalseAnswer = String(question.answer ?? 'True').toLowerCase() === 'false' ? 'False' : 'True'
+    baseQuestion.correctAnswers = [trueFalseAnswer]
+  } else if (type === 'fill_in_the_blanks') {
+    baseQuestion.blanks = Array.isArray(question.blanks) && question.blanks.length > 0 ? question.blanks : ['']
+  } else {
+    baseQuestion.sampleAnswer = Array.isArray(question.answer)
+      ? String(question.answer[0] ?? '')
+      : String(question.answer ?? '')
+  }
+
+  return baseQuestion
+}
+
+const mapRulesFromItem = (item: SubjectEcrItem, type: AssessmentMethodType): AssessmentMethodRules => {
+  const contentSettings =
+    item.content && typeof item.content === 'object' && item.content.settings ? item.content.settings : {}
+  const merged = {
+    ...DEFAULT_RULES_BY_TYPE[type],
+    ...(contentSettings ?? {}),
+    ...(item.settings ?? {}),
+  }
+  return {
+    maxAttempts: Math.max(1, Number(merged.max_attempts ?? merged.maxAttempts ?? DEFAULT_RULES_BY_TYPE[type].maxAttempts)),
+    timeLimitMinutes:
+      merged.time_limit_minutes == null && merged.timeLimitMinutes == null
+        ? null
+        : Math.max(1, Number(merged.time_limit_minutes ?? merged.timeLimitMinutes)),
+    passMark:
+      merged.pass_mark == null && merged.passMark == null
+        ? null
+        : Math.max(0, Math.min(100, Number(merged.pass_mark ?? merged.passMark))),
+    randomizeQuestions: Boolean(merged.randomize_questions ?? merged.randomizeQuestions),
+  }
+}
+
+const fromSubjectEcrItem = (item: SubjectEcrItem): AssessmentMethod => {
+  const type = (item.type ?? 'quiz') as AssessmentMethodType
+  const questions = (item.content?.questions ?? []).map(mapQuestionFromItem)
+  return {
+    id: item.id,
+    subjectEcrId: item.subject_ecr_id,
+    type,
+    status: (item.status ?? 'published') as AssessmentPublishStatus,
+    title: item.title ?? '',
+    description: item.description ?? '',
+    quarter: item.quarter ?? '1',
+    scheduledDate: item.scheduled_date ?? null,
+    openAt: item.open_at ?? null,
+    closeAt: item.close_at ?? null,
+    dueAt: item.due_at ?? null,
+    allowLateSubmission: Boolean(item.allow_late_submission),
+    rules: mapRulesFromItem(item, type),
+    questions,
+    createdAt: (item as any).created_at,
+    updatedAt: (item as any).updated_at,
+  }
+}
+
+const normalizeQuestionForPayload = (question: AssessmentMethodQuestion) => {
+  const base = {
+    type: question.type,
+    question: question.prompt.trim(),
+    points: Number.isFinite(question.points) ? question.points : 1,
+  }
+
+  if (question.type === 'single_choice') {
+    return {
+      ...base,
+      choices: question.choices.map((choice) => choice.trim()).filter(Boolean),
+      answer: question.correctAnswers[0] ?? 'A',
+    }
+  }
+
+  if (question.type === 'multiple_choice') {
+    return {
+      ...base,
+      choices: question.choices.map((choice) => choice.trim()).filter(Boolean),
+      answer: question.correctAnswers.length > 0 ? question.correctAnswers : ['A'],
+      allow_multiple: true,
+    }
+  }
+
+  if (question.type === 'true_false') {
+    return {
+      ...base,
+      choices: ['True', 'False'],
+      answer: question.correctAnswers[0] === 'False' ? 'False' : 'True',
+    }
+  }
+
+  if (question.type === 'fill_in_the_blanks') {
+    return {
+      ...base,
+      blanks: question.blanks.map((blank) => blank.trim()).filter(Boolean),
+    }
+  }
+
+  return {
+    ...base,
+    answer: question.sampleAnswer.trim(),
+  }
+}
+
+const toSubjectEcrItemPayload = (input: AssessmentMethodInput): Omit<SubjectEcrItem, 'id'> => {
+  const totalPoints = input.questions.reduce((sum, question) => sum + (Number(question.points) || 0), 0)
+  return {
+    subject_ecr_id: input.subjectEcrId,
+    type: input.type,
+    status: input.status,
+    title: input.title.trim(),
+    description: input.description.trim() || undefined,
+    quarter: input.quarter,
+    scheduled_date: input.scheduledDate,
+    open_at: input.openAt,
+    close_at: input.closeAt,
+    due_at: input.dueAt,
+    allow_late_submission: input.allowLateSubmission,
+    score: totalPoints,
+    settings: {
+      max_attempts: input.rules.maxAttempts,
+      time_limit_minutes: input.rules.timeLimitMinutes,
+      pass_mark: input.rules.passMark,
+      randomize_questions: input.rules.randomizeQuestions,
+    },
+    content: {
+      settings: {
+        max_attempts: input.rules.maxAttempts,
+        time_limit_minutes: input.rules.timeLimitMinutes,
+        pass_mark: input.rules.passMark,
+        randomize_questions: input.rules.randomizeQuestions,
+      },
+      questions: input.questions.map(normalizeQuestionForPayload),
+    },
+  }
+}
+
+class AssessmentMethodService {
+  async listBySubject(subjectId: string, type: AssessmentMethodType): Promise<AssessmentMethod[]> {
+    const response = await subjectEcrItemService.listBySubject({ subject_id: subjectId, type })
+    const items = (response?.data ?? []) as SubjectEcrItem[]
+    return items.map(fromSubjectEcrItem)
+  }
+
+  async create(input: AssessmentMethodInput) {
+    return subjectEcrItemService.create(toSubjectEcrItemPayload(input))
+  }
+
+  async update(id: string, input: AssessmentMethodInput) {
+    return subjectEcrItemService.update(id, toSubjectEcrItemPayload(input))
+  }
+
+  async remove(id: string) {
+    return subjectEcrItemService.delete(id)
+  }
+}
+
+export const assessmentMethodService = new AssessmentMethodService()
+export { DEFAULT_RULES_BY_TYPE }

--- a/app/src/services/studentAssessmentService.ts
+++ b/app/src/services/studentAssessmentService.ts
@@ -3,21 +3,29 @@ import { api } from '@/lib/api';
 export interface StudentAssessmentItem {
   id: string;
   type: string;
+  status?: 'draft' | 'published';
   title: string;
   description?: string;
   quarter?: string;
   academic_year?: string;
   max_score?: number;
   scheduled_date?: string;
+  open_at?: string | null;
+  close_at?: string | null;
+  due_at?: string | null;
+  allow_late_submission?: boolean;
   subject_title?: string;
   has_questions: boolean;
   attempt_status: 'not_started' | 'in_progress' | 'submitted';
   attempt_score?: number | null;
   attempt_max_score?: number | null;
   attempt_submitted_at?: string | null;
+  attempts_used?: number;
+  attempts_allowed?: number;
+  can_retake?: boolean;
 }
 
-export type QuestionType = 'true_false' | 'single_choice' | 'multiple_choice' | 'fill_in_the_blanks';
+export type QuestionType = 'true_false' | 'single_choice' | 'multiple_choice' | 'fill_in_the_blanks' | 'short_answer' | 'essay';
 
 export interface AssessmentQuestion {
   index: number;
@@ -26,19 +34,33 @@ export interface AssessmentQuestion {
   choices?: string[];
   points: number;
   num_blanks?: number; // for fill_in_the_blanks
+  placeholder?: string;
 }
 
 export interface TakeAssessmentPayload {
   id: string;
   type: string;
+  status?: 'draft' | 'published';
   title: string;
   description?: string;
   quarter?: string;
   max_score: number;
   subject_title?: string;
+  open_at?: string | null;
+  close_at?: string | null;
+  due_at?: string | null;
+  allow_late_submission?: boolean;
+  settings?: {
+    max_attempts?: number;
+    time_limit_minutes?: number | null;
+    pass_mark?: number | null;
+    randomize_questions?: boolean;
+  };
+  attempts_used?: number;
+  attempts_allowed?: number;
   questions: AssessmentQuestion[];
   attempt_id: string;
-  answers: Record<string, string>;
+  answers: Record<string, string | string[]>;
 }
 
 export interface SubmitResult {

--- a/app/src/services/subjectEcrItemService.ts
+++ b/app/src/services/subjectEcrItemService.ts
@@ -4,13 +4,27 @@ export interface SubjectEcrItem {
   id?: string;
   subject_ecr_id: string;
   type?: string;
+  status?: 'draft' | 'published';
   title: string;
   description?: string;
+  settings?: {
+    max_attempts?: number;
+    time_limit_minutes?: number | null;
+    pass_mark?: number | null;
+    randomize_questions?: boolean;
+  };
   content?: {
+    settings?: {
+      max_attempts?: number;
+      time_limit_minutes?: number | null;
+      pass_mark?: number | null;
+      randomize_questions?: boolean;
+    };
     questions?: Array<{
-      type: 'true_false' | 'single_choice' | 'multiple_choice' | 'fill_in_the_blanks';
+      type: 'true_false' | 'single_choice' | 'multiple_choice' | 'fill_in_the_blanks' | 'short_answer' | 'essay';
       question: string;
       choices?: string[];
+      allow_multiple?: boolean;
       answer?: string | string[]; // string for single/true_false, string[] or "A,B" for multiple_choice
       blanks?: string[]; // correct answers in order for fill_in_the_blanks
       points?: number;
@@ -20,6 +34,10 @@ export interface SubjectEcrItem {
   quarter?: string;
   academic_year?: string;
   scheduled_date?: string | null; // YYYY-MM-DD
+  open_at?: string | null;
+  close_at?: string | null;
+  due_at?: string | null;
+  allow_late_submission?: boolean;
 }
 
 class SubjectEcrItemService {


### PR DESCRIPTION
Adds a new "Assessment Methods" tab and a full-screen drag-and-drop assessment builder to the `assigned-subjects/:id` page, enabling creation of quizzes, assignments, and exams.

---
<p><a href="https://cursor.com/agents/bc-3b7ba942-ee84-4452-b9ca-91e6d46bd6b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3b7ba942-ee84-4452-b9ca-91e6d46bd6b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new persisted scheduling/rules fields and changes student assessment availability/attempt handling, which could affect when students can see/start/retake assessments after the migration. UI overhaul is sizable but largely additive around the existing `SubjectEcrItem` API.
> 
> **Overview**
> Adds an **Assessment Methods** workflow for quizzes/assignments/exams: a new full-screen drag-and-drop builder in `AssignedSubjects` (replacing the previous lightweight modal) and a new `assessmentMethodService` that maps builder state to `SubjectEcrItem` create/update/list/delete.
> 
> Extends `subject_ecr_items` with persisted assessment metadata (`status`, `settings`, `open_at`/`close_at`/`due_at`, `allow_late_submission`) and updates `SubjectEcrItemController` validation/filtering to accept these fields, additional question types (`short_answer`, `essay`), and `allow_multiple`.
> 
> Updates the student assessment API to **only expose published** items, enforce availability windows and max-attempt rules, and return richer attempt metadata (attempt counts, retake eligibility, schedule/settings). Student-taking UI/types are updated to support `short_answer`/`essay` inputs and consistent choice lettering.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b5434dd888dbaf2a3ec75ac236821be4cec665f7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->