### PR TITLE
Add payment void workflow to Finance ledger

### DIFF
--- a/api/app/Http/Controllers/PaymentVoidRequestController.php
+++ b/api/app/Http/Controllers/PaymentVoidRequestController.php
@@ -1,0 +1,299 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Auth\StudentPortalUser;
+use App\Models\PaymentTransaction;
+use App\Models\PaymentVoidRequest;
+use App\Models\StudentPayment;
+use App\Models\User;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+
+class PaymentVoidRequestController extends Controller
+{
+    /** Roles that may request a void (creates a pending request). */
+    private const REQUESTER_ROLES = ['finance'];
+
+    /** Roles that may approve/disapprove — and whose own voids auto-approve. */
+    private const APPROVER_ROLES = ['institution-administrator', 'principal', 'super-administrator'];
+
+    private function roleSlug(Request $request): ?string
+    {
+        $user = $request->user();
+        if (! $user instanceof User) {
+            return null;
+        }
+
+        return $user->getRole()?->slug;
+    }
+
+    private function canApprove(Request $request): bool
+    {
+        $slug = $this->roleSlug($request);
+
+        return $slug !== null && in_array($slug, self::APPROVER_ROLES, true);
+    }
+
+    private function canRequest(Request $request): bool
+    {
+        $slug = $this->roleSlug($request);
+
+        return $slug !== null
+            && (in_array($slug, self::REQUESTER_ROLES, true) || in_array($slug, self::APPROVER_ROLES, true));
+    }
+
+    private function resolveInstitutionId(Request $request): ?string
+    {
+        $user = $request->user();
+        if (! $user instanceof User) {
+            return null;
+        }
+
+        $institutionId = $user->getDefaultInstitutionId();
+        if (! $institutionId) {
+            $institutionId = $user->userInstitutions()->first()?->institution_id;
+        }
+
+        return $institutionId;
+    }
+
+    /**
+     * List void requests for the user's institution, optionally filtered by status.
+     */
+    public function index(Request $request): JsonResponse
+    {
+        if ($request->user() instanceof StudentPortalUser || ! $this->canRequest($request)) {
+            return response()->json(['success' => false, 'message' => 'Forbidden.'], 403);
+        }
+
+        $institutionId = $this->resolveInstitutionId($request);
+        if (! $institutionId) {
+            return response()->json([
+                'success' => false,
+                'message' => 'User does not have any institution assigned.',
+            ], 400);
+        }
+
+        $query = PaymentVoidRequest::query()
+            ->with(['student:id,first_name,middle_name,last_name', 'requester:id,first_name,last_name', 'reviewer:id,first_name,last_name'])
+            ->where('institution_id', $institutionId);
+
+        $status = $request->get('status');
+        if (in_array($status, ['pending', 'approved', 'disapproved'], true)) {
+            $query->where('status', $status);
+        }
+
+        $requests = $query->orderByDesc('created_at')->get();
+
+        return response()->json([
+            'success' => true,
+            'data' => $requests,
+        ]);
+    }
+
+    /**
+     * Create a void request for a recorded payment (anchored on its receipt).
+     *
+     * Finance → pending request. Admin (approver) → created already approved and
+     * the payment is voided immediately. A note is required in both cases.
+     */
+    public function store(Request $request): JsonResponse
+    {
+        if ($request->user() instanceof StudentPortalUser || ! $this->canRequest($request)) {
+            return response()->json(['success' => false, 'message' => 'Forbidden.'], 403);
+        }
+
+        $institutionId = $this->resolveInstitutionId($request);
+        if (! $institutionId) {
+            return response()->json([
+                'success' => false,
+                'message' => 'User does not have any institution assigned.',
+            ], 400);
+        }
+
+        $validated = $request->validate([
+            'receipt_number' => 'required|string|max:255',
+            'request_note' => 'required|string|max:2000',
+        ]);
+
+        $receiptNumber = $validated['receipt_number'];
+
+        // Resolve every active (non-voided) payment line sharing this receipt.
+        $payments = StudentPayment::where('institution_id', $institutionId)
+            ->where('receipt_number', $receiptNumber)
+            ->whereNull('voided_at')
+            ->get();
+
+        if ($payments->isEmpty()) {
+            return response()->json([
+                'success' => false,
+                'message' => 'No active payment found for this receipt. It may already be voided.',
+            ], 422);
+        }
+
+        // Prevent duplicate pending requests for the same receipt.
+        $existingPending = PaymentVoidRequest::where('institution_id', $institutionId)
+            ->where('receipt_number', $receiptNumber)
+            ->where('status', PaymentVoidRequest::STATUS_PENDING)
+            ->exists();
+
+        if ($existingPending) {
+            return response()->json([
+                'success' => false,
+                'message' => 'A void request for this receipt is already pending approval.',
+            ], 422);
+        }
+
+        $first = $payments->first();
+        $transactionId = $payments->firstWhere('payment_transaction_id', '!=', null)?->payment_transaction_id;
+        $amount = (float) $payments->sum('amount');
+        $isApprover = $this->canApprove($request);
+        $userId = $request->user()?->id;
+
+        $voidRequest = DB::transaction(function () use (
+            $institutionId,
+            $first,
+            $receiptNumber,
+            $transactionId,
+            $amount,
+            $validated,
+            $isApprover,
+            $userId,
+            $payments
+        ) {
+            $voidRequest = PaymentVoidRequest::create([
+                'institution_id' => $institutionId,
+                'student_id' => $first->student_id,
+                'academic_year' => $first->academic_year,
+                'receipt_number' => $receiptNumber,
+                'payment_transaction_id' => $transactionId,
+                'target_payment_id' => $transactionId ? null : $first->id,
+                'amount' => $amount,
+                'status' => $isApprover ? PaymentVoidRequest::STATUS_APPROVED : PaymentVoidRequest::STATUS_PENDING,
+                'request_note' => $validated['request_note'],
+                'requested_by' => $userId,
+                'reviewed_by' => $isApprover ? $userId : null,
+                'reviewed_at' => $isApprover ? now() : null,
+            ]);
+
+            // Admin-initiated voids apply immediately.
+            if ($isApprover) {
+                $this->applyVoid($payments, $userId, $validated['request_note']);
+            }
+
+            return $voidRequest;
+        });
+
+        $voidRequest->load(['student:id,first_name,middle_name,last_name', 'requester:id,first_name,last_name', 'reviewer:id,first_name,last_name']);
+
+        return response()->json([
+            'success' => true,
+            'message' => $isApprover
+                ? 'Payment voided successfully.'
+                : 'Void request submitted for approval.',
+            'data' => $voidRequest,
+        ], 201);
+    }
+
+    /**
+     * Approve a pending void request and void the payment.
+     */
+    public function approve(Request $request, string $id): JsonResponse
+    {
+        if (! $this->canApprove($request)) {
+            return response()->json(['success' => false, 'message' => 'Forbidden.'], 403);
+        }
+
+        $institutionId = $this->resolveInstitutionId($request);
+        $voidRequest = PaymentVoidRequest::where('institution_id', $institutionId)->find($id);
+
+        if (! $voidRequest) {
+            return response()->json(['success' => false, 'message' => 'Void request not found.'], 404);
+        }
+        if ($voidRequest->status !== PaymentVoidRequest::STATUS_PENDING) {
+            return response()->json(['success' => false, 'message' => 'Only pending requests can be approved.'], 422);
+        }
+
+        $userId = $request->user()?->id;
+
+        DB::transaction(function () use ($voidRequest, $institutionId, $userId) {
+            $payments = StudentPayment::where('institution_id', $institutionId)
+                ->where('receipt_number', $voidRequest->receipt_number)
+                ->whereNull('voided_at')
+                ->get();
+
+            $this->applyVoid($payments, $userId, $voidRequest->request_note);
+
+            $voidRequest->update([
+                'status' => PaymentVoidRequest::STATUS_APPROVED,
+                'reviewed_by' => $userId,
+                'reviewed_at' => now(),
+            ]);
+        });
+
+        $voidRequest->load(['student:id,first_name,middle_name,last_name', 'requester:id,first_name,last_name', 'reviewer:id,first_name,last_name']);
+
+        return response()->json([
+            'success' => true,
+            'message' => 'Void request approved. Payment voided.',
+            'data' => $voidRequest,
+        ]);
+    }
+
+    /**
+     * Disapprove a pending void request (payment stays active).
+     */
+    public function disapprove(Request $request, string $id): JsonResponse
+    {
+        if (! $this->canApprove($request)) {
+            return response()->json(['success' => false, 'message' => 'Forbidden.'], 403);
+        }
+
+        $institutionId = $this->resolveInstitutionId($request);
+        $voidRequest = PaymentVoidRequest::where('institution_id', $institutionId)->find($id);
+
+        if (! $voidRequest) {
+            return response()->json(['success' => false, 'message' => 'Void request not found.'], 404);
+        }
+        if ($voidRequest->status !== PaymentVoidRequest::STATUS_PENDING) {
+            return response()->json(['success' => false, 'message' => 'Only pending requests can be disapproved.'], 422);
+        }
+
+        $validated = $request->validate([
+            'review_note' => 'required|string|max:2000',
+        ]);
+
+        $voidRequest->update([
+            'status' => PaymentVoidRequest::STATUS_DISAPPROVED,
+            'review_note' => $validated['review_note'],
+            'reviewed_by' => $request->user()?->id,
+            'reviewed_at' => now(),
+        ]);
+
+        $voidRequest->load(['student:id,first_name,middle_name,last_name', 'requester:id,first_name,last_name', 'reviewer:id,first_name,last_name']);
+
+        return response()->json([
+            'success' => true,
+            'message' => 'Void request disapproved.',
+            'data' => $voidRequest,
+        ]);
+    }
+
+    /**
+     * Stamp the void on every payment row of the receipt.
+     *
+     * @param  \Illuminate\Support\Collection<int, StudentPayment>  $payments
+     */
+    private function applyVoid($payments, ?string $userId, string $note): void
+    {
+        foreach ($payments as $payment) {
+            $payment->update([
+                'voided_at' => now(),
+                'voided_by' => $userId,
+                'void_note' => $note,
+            ]);
+        }
+    }
+}

--- a/api/app/Http/Controllers/StudentFinanceController.php
+++ b/api/app/Http/Controllers/StudentFinanceController.php
@@ -77,13 +77,17 @@ class StudentFinanceController extends Controller
                 ->get();
         }
 
-        $payments = StudentPayment::with(['schoolFee', 'receivedBy'])
+        $payments = StudentPayment::with(['schoolFee', 'receivedBy', 'voidedBy'])
             ->where('institution_id', $institutionId)
             ->where('student_id', $studentId)
             ->where('academic_year', $academicYear)
             ->orderBy('payment_date')
             ->orderBy('created_at')
             ->get();
+
+        // Voided payments stay visible in the ledger for audit, but they are
+        // excluded from all totals / running balance and per-fee breakdowns.
+        $activePayments = $payments->whereNull('voided_at');
 
         $discounts = StudentDiscount::with(['schoolFee', 'creator'])
             ->where('institution_id', $institutionId)
@@ -117,7 +121,7 @@ class StudentFinanceController extends Controller
         $discountsWithAmount = $this->applyDiscounts($discounts, $feeAmountMap, $standardCharges);
         $gradeLevelDiscountsWithAmount = $this->applyDiscounts($gradeLevelDiscounts, $feeAmountMap, $standardCharges);
         $discountsTotal = (float) $discountsWithAmount->sum('amount') + (float) $gradeLevelDiscountsWithAmount->sum('amount');
-        $paymentsTotal = (float) $payments->sum('amount');
+        $paymentsTotal = (float) $activePayments->sum('amount');
         $balanceForward = $this->calculateBalanceForward(
             $studentSections,
             $academicYear,
@@ -231,6 +235,11 @@ class StudentFinanceController extends Controller
             $processedByName = $receivedBy
                 ? trim(($receivedBy->first_name ?? '') . ' ' . ($receivedBy->last_name ?? ''))
                 : null;
+            $isVoided = $payment->voided_at !== null;
+            $voidedByUser = $payment->voidedBy;
+            $voidedByName = $voidedByUser
+                ? trim(($voidedByUser->first_name ?? '') . ' ' . ($voidedByUser->last_name ?? ''))
+                : null;
 
             return [
                 'type' => 'payment',
@@ -243,6 +252,10 @@ class StudentFinanceController extends Controller
                 'fee_id' => $payment->school_fee_id,
                 'fee_name' => $feeName,
                 'processed_by' => $processedByName,
+                'voided' => $isVoided,
+                'voided_at' => $payment->voided_at?->toDateTimeString(),
+                'voided_by' => $voidedByName,
+                'void_note' => $payment->void_note,
             ];
         });
 
@@ -267,7 +280,10 @@ class StudentFinanceController extends Controller
 
         $runningBalance = 0.0;
         $entries = $entries->map(function ($entry) use (&$runningBalance) {
-            $runningBalance += (float) $entry['amount'];
+            // Voided payments are shown for audit but must not move the balance.
+            if (empty($entry['voided'])) {
+                $runningBalance += (float) $entry['amount'];
+            }
             $entry['running_balance'] = round($runningBalance, 2);
             return $entry;
         });
@@ -276,7 +292,7 @@ class StudentFinanceController extends Controller
 
         // Per-fee breakdown used by the cashiering (POS) screen to show the
         // outstanding amount for each fee so the cashier can pay toward each.
-        $paidByFee = $payments
+        $paidByFee = $activePayments
             ->filter(fn ($payment) => $payment->school_fee_id)
             ->groupBy('school_fee_id')
             ->map(fn ($group) => (float) $group->sum('amount'));
@@ -318,7 +334,7 @@ class StudentFinanceController extends Controller
             ];
         }))->values();
 
-        $unallocatedPayments = (float) $payments
+        $unallocatedPayments = (float) $activePayments
             ->filter(fn ($payment) => !$payment->school_fee_id)
             ->sum('amount');
 
@@ -441,6 +457,7 @@ class StudentFinanceController extends Controller
             ->where('institution_id', $institutionId)
             ->where('student_id', $studentId)
             ->where('academic_year', $academicYear)
+            ->whereNull('voided_at')
             ->orderBy('payment_date')
             ->orderBy('created_at')
             ->get();

--- a/api/app/Models/PaymentVoidRequest.php
+++ b/api/app/Models/PaymentVoidRequest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+
+class PaymentVoidRequest extends Model
+{
+    use HasFactory, HasUuids;
+
+    public const STATUS_PENDING = 'pending';
+    public const STATUS_APPROVED = 'approved';
+    public const STATUS_DISAPPROVED = 'disapproved';
+
+    protected $fillable = [
+        'institution_id',
+        'student_id',
+        'academic_year',
+        'receipt_number',
+        'payment_transaction_id',
+        'target_payment_id',
+        'amount',
+        'status',
+        'request_note',
+        'review_note',
+        'requested_by',
+        'reviewed_by',
+        'reviewed_at',
+    ];
+
+    protected $casts = [
+        'amount' => 'decimal:2',
+        'reviewed_at' => 'datetime',
+    ];
+
+    public function institution()
+    {
+        return $this->belongsTo(Institution::class);
+    }
+
+    public function student()
+    {
+        return $this->belongsTo(Student::class);
+    }
+
+    public function paymentTransaction()
+    {
+        return $this->belongsTo(PaymentTransaction::class);
+    }
+
+    public function requester()
+    {
+        return $this->belongsTo(User::class, 'requested_by');
+    }
+
+    public function reviewer()
+    {
+        return $this->belongsTo(User::class, 'reviewed_by');
+    }
+}

--- a/api/app/Models/StudentPayment.php
+++ b/api/app/Models/StudentPayment.php
@@ -25,12 +25,21 @@ class StudentPayment extends Model
         'receipt_number',
         'remarks',
         'received_by',
+        'voided_at',
+        'voided_by',
+        'void_note',
     ];
 
     protected $casts = [
         'amount' => 'decimal:2',
         'payment_date' => 'date',
+        'voided_at' => 'datetime',
     ];
+
+    public function voidedBy()
+    {
+        return $this->belongsTo(User::class, 'voided_by');
+    }
 
     public function student()
     {

--- a/api/database/migrations/2026_06_05_000001_add_void_columns_to_student_payments_table.php
+++ b/api/database/migrations/2026_06_05_000001_add_void_columns_to_student_payments_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Soft-void support for recorded payments. A voided payment row is kept for
+     * audit purposes but is excluded from ledger totals / running balance. When
+     * a whole receipt is voided, every student_payments row sharing that
+     * receipt_number is stamped here.
+     */
+    public function up(): void
+    {
+        Schema::table('student_payments', function (Blueprint $table) {
+            $table->timestamp('voided_at')->nullable()->after('received_by');
+            $table->foreignUuid('voided_by')->nullable()->after('voided_at')
+                ->references('id')->on('users')->onDelete('set null');
+            $table->text('void_note')->nullable()->after('voided_by');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('student_payments', function (Blueprint $table) {
+            $table->dropConstrainedForeignId('voided_by');
+            $table->dropColumn(['voided_at', 'void_note']);
+        });
+    }
+};

--- a/api/database/migrations/2026_06_05_000002_create_payment_void_requests_table.php
+++ b/api/database/migrations/2026_06_05_000002_create_payment_void_requests_table.php
@@ -1,0 +1,50 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Void-request workflow for recorded payments.
+     *
+     * The finance role requests a void (status = pending) and must supply a
+     * note. An institution-administrator / principal approves or disapproves.
+     * When an admin initiates the void themselves the request is created
+     * already approved (auto-approved). A void targets a whole receipt: either
+     * a payment_transaction (multi-fee cashiering) or a single legacy
+     * student_payment, both resolved via receipt_number when applied.
+     */
+    public function up(): void
+    {
+        Schema::create('payment_void_requests', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->foreignUuid('institution_id')->references('id')->on('institutions')->onDelete('cascade');
+            $table->foreignUuid('student_id')->references('id')->on('students')->onDelete('cascade');
+            $table->string('academic_year');
+            $table->string('receipt_number');
+            $table->foreignUuid('payment_transaction_id')->nullable()
+                ->references('id')->on('payment_transactions')->onDelete('set null');
+            $table->foreignUuid('target_payment_id')->nullable()
+                ->references('id')->on('student_payments')->onDelete('set null');
+            $table->decimal('amount', 12, 2)->default(0);
+            $table->string('status')->default('pending'); // pending | approved | disapproved
+            $table->text('request_note');
+            $table->text('review_note')->nullable();
+            $table->foreignUuid('requested_by')->nullable()->references('id')->on('users')->onDelete('set null');
+            $table->foreignUuid('reviewed_by')->nullable()->references('id')->on('users')->onDelete('set null');
+            $table->timestamp('reviewed_at')->nullable();
+            $table->timestamps();
+
+            $table->index('status');
+            $table->index(['institution_id', 'status']);
+            $table->index('receipt_number');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('payment_void_requests');
+    }
+};

--- a/api/routes/api.php
+++ b/api/routes/api.php
@@ -29,6 +29,7 @@ use App\Http\Controllers\FinanceDashboardController;
 use App\Http\Controllers\StudentDiscountController;
 use App\Http\Controllers\StudentPaymentController;
 use App\Http\Controllers\PaymentTransactionController;
+use App\Http\Controllers\PaymentVoidRequestController;
 use App\Http\Controllers\StudentFinanceController;
 use App\Http\Controllers\StudentPaymentPlanController;
 use App\Http\Controllers\StudentOnlinePaymentController;
@@ -308,6 +309,12 @@ Route::middleware('auth.token')->group(function () {
     Route::put('student-additional-fees/{id}', [StudentAdditionalFeeController::class, 'update']);
     Route::patch('student-additional-fees/{id}', [StudentAdditionalFeeController::class, 'update']);
     Route::delete('student-additional-fees/{id}', [StudentAdditionalFeeController::class, 'destroy']);
+
+    // Payment void requests (finance requests, admin approves/disapproves)
+    Route::get('payment-void-requests', [PaymentVoidRequestController::class, 'index']);
+    Route::post('payment-void-requests', [PaymentVoidRequestController::class, 'store']);
+    Route::post('payment-void-requests/{id}/approve', [PaymentVoidRequestController::class, 'approve']);
+    Route::post('payment-void-requests/{id}/disapprove', [PaymentVoidRequestController::class, 'disapprove']);
 
     // Receipt templates
     Route::apiResource('receipt-templates', ReceiptTemplateController::class);

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -139,6 +139,7 @@ function App() {
               <Route path="finance/collections" element={<Finance />} />
               <Route path="finance/discounts" element={<Finance />} />
               <Route path="finance/receipt-builder" element={<Finance />} />
+              <Route path="finance/void-requests" element={<Finance />} />
               <Route path="settings" element={<Settings />} />
               <Route path="hris/devices" element={<HrisDevices />} />
               <Route path="hris/zk-users" element={<HrisZkUsers />} />

--- a/app/src/pages/Finance/Finance.tsx
+++ b/app/src/pages/Finance/Finance.tsx
@@ -16,13 +16,17 @@ import { studentPaymentService } from '../../services/studentPaymentService'
 import { studentFinanceService } from '../../services/studentFinanceService'
 import { studentDiscountService } from '../../services/studentDiscountService'
 import { studentAdditionalFeeService } from '../../services/studentAdditionalFeeService'
+import { paymentVoidService } from '../../services/paymentVoidService'
+import { useAuth } from '../../hooks/useAuth'
 import { StudentNOAPDF } from '../../components/StudentNOAPDF'
 import DashboardCharts from './DashboardCharts'
 import CollectionsView from './CollectionsView'
 import DiscountsView from './DiscountsView'
 import ReceiptBuilderView from './ReceiptBuilderView'
 import ReceiptPrintModal from './ReceiptPrintModal'
-import type { SchoolFee, SchoolFeeDefault, Student, CreateStudentDiscountData, CreateStudentAdditionalFeeData, CreatePaymentTransactionData, PaymentTransaction } from '../../types'
+import type { SchoolFee, SchoolFeeDefault, Student, CreateStudentDiscountData, CreateStudentAdditionalFeeData, CreatePaymentTransactionData, PaymentTransaction, StudentLedgerEntry, PaymentVoidStatus } from '../../types'
+
+const VOID_APPROVER_ROLES = ['institution-administrator', 'principal', 'super-administrator']
 
 const Finance: React.FC = () => {
   const queryClient = useQueryClient()
@@ -36,8 +40,14 @@ const Finance: React.FC = () => {
     if (pathname.endsWith('/collections')) return 'collections'
     if (pathname.endsWith('/discounts')) return 'discounts'
     if (pathname.endsWith('/receipt-builder')) return 'receipt-builder'
+    if (pathname.endsWith('/void-requests')) return 'void-requests'
     return 'dashboard'
   }, [location.pathname])
+
+  const { user } = useAuth()
+  const roleSlug: string | undefined = user?.role?.slug
+  const isVoidApprover = Boolean(roleSlug && VOID_APPROVER_ROLES.includes(roleSlug))
+  const canRequestVoid = roleSlug === 'finance' || isVoidApprover
 
   const currentYear = new Date().getFullYear()
   const defaultAcademicYear = `${currentYear}-${currentYear + 1}`
@@ -207,6 +217,80 @@ const Finance: React.FC = () => {
       toast.error(error.response?.data?.message || 'Failed to remove fee.')
     },
   })
+
+  // ---- Payment void workflow ----
+  const [voidEntry, setVoidEntry] = useState<StudentLedgerEntry | null>(null)
+  const [voidNote, setVoidNote] = useState('')
+  const [voidStatusFilter, setVoidStatusFilter] = useState<PaymentVoidStatus>('pending')
+  const [disapproveTarget, setDisapproveTarget] = useState<string | null>(null)
+  const [disapproveNote, setDisapproveNote] = useState('')
+
+  const voidRequestsQuery = useQuery({
+    queryKey: ['payment-void-requests', voidStatusFilter],
+    queryFn: () => paymentVoidService.list(voidStatusFilter),
+    enabled: view === 'void-requests' && canRequestVoid,
+  })
+
+  const invalidateAfterVoid = () => {
+    queryClient.invalidateQueries({ queryKey: ['payment-void-requests'] })
+    queryClient.invalidateQueries({ queryKey: ['student-ledger'] })
+    queryClient.invalidateQueries({ queryKey: ['student-noa'] })
+  }
+
+  const createVoidMutation = useMutation({
+    mutationFn: (payload: { receipt_number: string; request_note: string }) =>
+      paymentVoidService.create(payload),
+    onSuccess: (response) => {
+      setVoidEntry(null)
+      setVoidNote('')
+      invalidateAfterVoid()
+      toast.success(response.message || 'Void request submitted.')
+    },
+    onError: (error: any) => {
+      toast.error(error.response?.data?.message || 'Failed to submit void request.')
+    },
+  })
+
+  const approveVoidMutation = useMutation({
+    mutationFn: (id: string) => paymentVoidService.approve(id),
+    onSuccess: () => {
+      invalidateAfterVoid()
+      toast.success('Void request approved.')
+    },
+    onError: (error: any) => {
+      toast.error(error.response?.data?.message || 'Failed to approve void request.')
+    },
+  })
+
+  const disapproveVoidMutation = useMutation({
+    mutationFn: (payload: { id: string; review_note: string }) =>
+      paymentVoidService.disapprove(payload.id, payload.review_note),
+    onSuccess: () => {
+      setDisapproveTarget(null)
+      setDisapproveNote('')
+      invalidateAfterVoid()
+      toast.success('Void request disapproved.')
+    },
+    onError: (error: any) => {
+      toast.error(error.response?.data?.message || 'Failed to disapprove void request.')
+    },
+  })
+
+  const handleVoidSubmit = (event: React.FormEvent) => {
+    event.preventDefault()
+    if (!voidEntry?.receipt_number) {
+      toast.error('This payment has no receipt number and cannot be voided.')
+      return
+    }
+    if (!voidNote.trim()) {
+      toast.error('A note is required to void a payment.')
+      return
+    }
+    createVoidMutation.mutate({
+      receipt_number: voidEntry.receipt_number,
+      request_note: voidNote.trim(),
+    })
+  }
 
   const handleLedgerAdditionalFeeSubmit = (event: React.FormEvent) => {
     event.preventDefault()
@@ -747,6 +831,18 @@ const Finance: React.FC = () => {
           >
             Receipt Builder
           </NavLink>
+          {canRequestVoid && (
+            <NavLink
+              to="/finance/void-requests"
+              className={({ isActive }) =>
+                `px-4 py-2 text-sm font-medium rounded-lg transition-colors ${
+                  isActive ? 'bg-indigo-600 text-white' : 'text-gray-700 hover:bg-gray-50'
+                }`
+              }
+            >
+              Void Requests
+            </NavLink>
+          )}
         </div>
       </div>
 
@@ -2101,6 +2197,11 @@ const Finance: React.FC = () => {
                             <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">
                               Processed By
                             </th>
+                            {canRequestVoid && (
+                              <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase">
+                                Action
+                              </th>
+                            )}
                           </tr>
                         </thead>
                         <tbody className="divide-y divide-gray-200 bg-white">
@@ -2109,17 +2210,34 @@ const Finance: React.FC = () => {
                               key={
                                 `${entry.type}-${entry.payment_id ?? entry.discount_id ?? entry.fee_id ?? index}`
                               }
+                              className={entry.voided ? 'bg-gray-50' : undefined}
                             >
                               <td className="px-4 py-3 text-sm text-gray-600 capitalize">
                                 {entry.type.replace('_', ' ')}
                               </td>
-                              <td className="px-4 py-3 text-sm text-gray-700">{entry.description}</td>
+                              <td className="px-4 py-3 text-sm text-gray-700">
+                                <span className={entry.voided ? 'line-through text-gray-400' : undefined}>
+                                  {entry.description}
+                                </span>
+                                {entry.voided && (
+                                  <span
+                                    className="ml-2 inline-flex items-center rounded-full bg-red-100 px-2 py-0.5 text-[10px] font-semibold uppercase text-red-700"
+                                    title={entry.void_note ? `Reason: ${entry.void_note}${entry.voided_by ? ` — by ${entry.voided_by}` : ''}` : 'Voided'}
+                                  >
+                                    Voided
+                                  </span>
+                                )}
+                              </td>
                               <td className="px-4 py-3 text-sm text-gray-600">
                                 {entry.date ?? '—'}
                               </td>
                               <td
                                 className={`px-4 py-3 text-sm text-right tabular-nums ${
-                                  entry.amount < 0 ? 'text-red-600' : 'text-gray-900'
+                                  entry.voided
+                                    ? 'text-gray-400 line-through'
+                                    : entry.amount < 0
+                                    ? 'text-red-600'
+                                    : 'text-gray-900'
                                 }`}
                               >
                                 ₱ {Number(entry.amount).toLocaleString('en-PH', {
@@ -2136,12 +2254,30 @@ const Finance: React.FC = () => {
                               <td className="px-4 py-3 text-sm text-gray-600">
                                 {entry.processed_by ?? '—'}
                               </td>
+                              {canRequestVoid && (
+                                <td className="px-4 py-3 text-sm text-right">
+                                  {entry.type === 'payment' && !entry.voided && entry.receipt_number ? (
+                                    <button
+                                      type="button"
+                                      onClick={() => {
+                                        setVoidEntry(entry)
+                                        setVoidNote('')
+                                      }}
+                                      className="text-red-600 hover:text-red-700 font-medium"
+                                    >
+                                      Void
+                                    </button>
+                                  ) : (
+                                    <span className="text-gray-300">—</span>
+                                  )}
+                                </td>
+                              )}
                             </tr>
                           ))}
                           {!ledgerQuery.data?.data?.entries?.length && (
                             <tr>
                               <td
-                                colSpan={6}
+                                colSpan={canRequestVoid ? 7 : 6}
                                 className="px-4 py-8 text-center text-gray-500"
                               >
                                 No ledger entries for this academic year.
@@ -2386,6 +2522,266 @@ const Finance: React.FC = () => {
       )}
 
       {view === 'receipt-builder' && <ReceiptBuilderView />}
+
+      {view === 'void-requests' && canRequestVoid && (
+        <div className="bg-white rounded-xl border border-gray-200 p-6 shadow-sm space-y-4">
+          <div className="flex items-center justify-between">
+            <div>
+              <h2 className="text-lg font-semibold text-gray-900">Payment Void Requests</h2>
+              <p className="text-sm text-gray-500">
+                {isVoidApprover
+                  ? 'Review and approve or disapprove void requests submitted by finance.'
+                  : 'Track the status of payment void requests you have submitted.'}
+              </p>
+            </div>
+            <div className="flex rounded-lg border border-gray-200 overflow-hidden">
+              {(['pending', 'approved', 'disapproved'] as PaymentVoidStatus[]).map((status) => (
+                <button
+                  key={status}
+                  type="button"
+                  onClick={() => setVoidStatusFilter(status)}
+                  className={`px-3 py-1.5 text-xs font-medium capitalize transition-colors ${
+                    voidStatusFilter === status
+                      ? 'bg-indigo-600 text-white'
+                      : 'bg-white text-gray-700 hover:bg-gray-50'
+                  }`}
+                >
+                  {status}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div className="overflow-x-auto rounded-lg border border-gray-200">
+            <table className="min-w-full divide-y divide-gray-200">
+              <thead className="bg-gray-50">
+                <tr>
+                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Receipt</th>
+                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Student</th>
+                  <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase">Amount</th>
+                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Reason</th>
+                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Requested By</th>
+                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Status</th>
+                  {isVoidApprover && (
+                    <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase">Action</th>
+                  )}
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-200 bg-white">
+                {voidRequestsQuery.isLoading && (
+                  <tr>
+                    <td colSpan={isVoidApprover ? 7 : 6} className="px-4 py-8 text-center text-gray-500">
+                      Loading void requests...
+                    </td>
+                  </tr>
+                )}
+                {!voidRequestsQuery.isLoading &&
+                  voidRequestsQuery.data?.data?.map((req) => {
+                    const studentName = req.student
+                      ? `${req.student.first_name} ${req.student.last_name}`
+                      : '—'
+                    const requesterName = req.requester
+                      ? `${req.requester.first_name} ${req.requester.last_name}`
+                      : '—'
+                    return (
+                      <tr key={req.id}>
+                        <td className="px-4 py-3 text-sm font-mono text-gray-700">{req.receipt_number}</td>
+                        <td className="px-4 py-3 text-sm text-gray-700">{studentName}</td>
+                        <td className="px-4 py-3 text-sm text-right tabular-nums text-gray-900">
+                          ₱ {Number(req.amount).toLocaleString('en-PH', {
+                            minimumFractionDigits: 2,
+                            maximumFractionDigits: 2,
+                          })}
+                        </td>
+                        <td className="px-4 py-3 text-sm text-gray-600 max-w-xs">
+                          <span title={req.request_note}>{req.request_note}</span>
+                          {req.review_note && (
+                            <span className="block text-xs text-gray-400 mt-1">
+                              Review: {req.review_note}
+                            </span>
+                          )}
+                        </td>
+                        <td className="px-4 py-3 text-sm text-gray-600">{requesterName}</td>
+                        <td className="px-4 py-3 text-sm">
+                          <span
+                            className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-semibold capitalize ${
+                              req.status === 'approved'
+                                ? 'bg-green-100 text-green-700'
+                                : req.status === 'disapproved'
+                                ? 'bg-red-100 text-red-700'
+                                : 'bg-amber-100 text-amber-700'
+                            }`}
+                          >
+                            {req.status}
+                          </span>
+                        </td>
+                        {isVoidApprover && (
+                          <td className="px-4 py-3 text-sm text-right whitespace-nowrap">
+                            {req.status === 'pending' ? (
+                              <div className="flex justify-end gap-2">
+                                <Button
+                                  type="button"
+                                  size="sm"
+                                  onClick={() => approveVoidMutation.mutate(req.id)}
+                                  loading={approveVoidMutation.isPending}
+                                  className="bg-green-600 hover:bg-green-700 text-white"
+                                >
+                                  Approve
+                                </Button>
+                                <Button
+                                  type="button"
+                                  size="sm"
+                                  variant="outline"
+                                  onClick={() => {
+                                    setDisapproveTarget(req.id)
+                                    setDisapproveNote('')
+                                  }}
+                                >
+                                  Disapprove
+                                </Button>
+                              </div>
+                            ) : (
+                              <span className="text-gray-300">—</span>
+                            )}
+                          </td>
+                        )}
+                      </tr>
+                    )
+                  })}
+                {!voidRequestsQuery.isLoading && !voidRequestsQuery.data?.data?.length && (
+                  <tr>
+                    <td colSpan={isVoidApprover ? 7 : 6} className="px-4 py-8 text-center text-gray-500">
+                      No {voidStatusFilter} void requests.
+                    </td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+
+      {/* Void request modal (from the ledger) */}
+      {voidEntry && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4">
+          <div className="w-full max-w-md rounded-xl bg-white shadow-xl">
+            <form onSubmit={handleVoidSubmit}>
+              <div className="px-5 py-4 border-b border-gray-100">
+                <h3 className="text-base font-semibold text-gray-900">Void Payment</h3>
+                <p className="text-sm text-gray-500 mt-1">
+                  {isVoidApprover
+                    ? 'This will void the payment immediately. A note is required.'
+                    : 'This submits a void request for admin approval. A note is required.'}
+                </p>
+              </div>
+              <div className="px-5 py-4 space-y-3">
+                <div className="rounded-lg bg-gray-50 px-3 py-2 text-sm text-gray-700">
+                  <div className="flex justify-between">
+                    <span className="text-gray-500">Receipt</span>
+                    <span className="font-mono">{voidEntry.receipt_number}</span>
+                  </div>
+                  <div className="flex justify-between">
+                    <span className="text-gray-500">Amount</span>
+                    <span className="tabular-nums">
+                      ₱ {Math.abs(Number(voidEntry.amount)).toLocaleString('en-PH', {
+                        minimumFractionDigits: 2,
+                        maximumFractionDigits: 2,
+                      })}
+                    </span>
+                  </div>
+                </div>
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1.5">
+                    Reason / Note <span className="text-red-500">*</span>
+                  </label>
+                  <textarea
+                    value={voidNote}
+                    onChange={(e) => setVoidNote(e.target.value)}
+                    rows={3}
+                    className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-indigo-500 focus:ring-indigo-500"
+                    placeholder="e.g. Duplicate entry, wrong amount, payment reversed"
+                  />
+                </div>
+              </div>
+              <div className="px-5 py-4 border-t border-gray-100 flex justify-end gap-2">
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => {
+                    setVoidEntry(null)
+                    setVoidNote('')
+                  }}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  type="submit"
+                  loading={createVoidMutation.isPending}
+                  className="bg-red-600 hover:bg-red-700 text-white"
+                >
+                  {isVoidApprover ? 'Void Payment' : 'Submit Request'}
+                </Button>
+              </div>
+            </form>
+          </div>
+        </div>
+      )}
+
+      {/* Disapprove modal */}
+      {disapproveTarget && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4">
+          <div className="w-full max-w-md rounded-xl bg-white shadow-xl">
+            <form
+              onSubmit={(e) => {
+                e.preventDefault()
+                if (!disapproveNote.trim()) {
+                  toast.error('A reason is required to disapprove.')
+                  return
+                }
+                disapproveVoidMutation.mutate({ id: disapproveTarget, review_note: disapproveNote.trim() })
+              }}
+            >
+              <div className="px-5 py-4 border-b border-gray-100">
+                <h3 className="text-base font-semibold text-gray-900">Disapprove Void Request</h3>
+                <p className="text-sm text-gray-500 mt-1">
+                  The payment will remain active. Provide a reason for the requester.
+                </p>
+              </div>
+              <div className="px-5 py-4">
+                <label className="block text-sm font-medium text-gray-700 mb-1.5">
+                  Reason <span className="text-red-500">*</span>
+                </label>
+                <textarea
+                  value={disapproveNote}
+                  onChange={(e) => setDisapproveNote(e.target.value)}
+                  rows={3}
+                  className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-indigo-500 focus:ring-indigo-500"
+                  placeholder="e.g. Payment is valid, please verify with the receipt"
+                />
+              </div>
+              <div className="px-5 py-4 border-t border-gray-100 flex justify-end gap-2">
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => {
+                    setDisapproveTarget(null)
+                    setDisapproveNote('')
+                  }}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  type="submit"
+                  loading={disapproveVoidMutation.isPending}
+                  className="bg-red-600 hover:bg-red-700 text-white"
+                >
+                  Disapprove
+                </Button>
+              </div>
+            </form>
+          </div>
+        </div>
+      )}
     </motion.div>
   )
 }

--- a/app/src/services/paymentVoidService.ts
+++ b/app/src/services/paymentVoidService.ts
@@ -1,0 +1,32 @@
+import { api } from '../lib/api'
+import type { ApiResponse, PaymentVoidRequest, PaymentVoidStatus } from '../types'
+
+class PaymentVoidService {
+  private baseUrl = '/payment-void-requests'
+
+  async list(status?: PaymentVoidStatus) {
+    const url = status ? `${this.baseUrl}?status=${status}` : this.baseUrl
+    const response = await api.get<ApiResponse<PaymentVoidRequest[]>>(url)
+    return response.data
+  }
+
+  async create(data: { receipt_number: string; request_note: string }) {
+    const response = await api.post<ApiResponse<PaymentVoidRequest>>(this.baseUrl, data)
+    return response.data
+  }
+
+  async approve(id: string) {
+    const response = await api.post<ApiResponse<PaymentVoidRequest>>(`${this.baseUrl}/${id}/approve`, {})
+    return response.data
+  }
+
+  async disapprove(id: string, review_note: string) {
+    const response = await api.post<ApiResponse<PaymentVoidRequest>>(
+      `${this.baseUrl}/${id}/disapprove`,
+      { review_note }
+    )
+    return response.data
+  }
+}
+
+export const paymentVoidService = new PaymentVoidService()

--- a/app/src/types/index.ts
+++ b/app/src/types/index.ts
@@ -317,6 +317,34 @@ export interface StudentLedgerEntry {
   discount_value?: number;
   running_balance?: number;
   processed_by?: string | null;
+  voided?: boolean;
+  voided_at?: string | null;
+  voided_by?: string | null;
+  void_note?: string | null;
+}
+
+export type PaymentVoidStatus = 'pending' | 'approved' | 'disapproved';
+
+export interface PaymentVoidRequest {
+  id: string;
+  institution_id: string;
+  student_id: string;
+  academic_year: string;
+  receipt_number: string;
+  payment_transaction_id?: string | null;
+  target_payment_id?: string | null;
+  amount: number | string;
+  status: PaymentVoidStatus;
+  request_note: string;
+  review_note?: string | null;
+  requested_by?: string | null;
+  reviewed_by?: string | null;
+  reviewed_at?: string | null;
+  created_at?: string;
+  updated_at?: string;
+  student?: { id: string; first_name: string; middle_name?: string | null; last_name: string };
+  requester?: { id: string; first_name: string; last_name: string } | null;
+  reviewer?: { id: string; first_name: string; last_name: string } | null;
 }
 
 export type StudentPaymentPlanType = 'monthly' | 'quarterly';


### PR DESCRIPTION
Finance can request to void a payment (whole receipt) with a required note, creating a pending request. Institution-administrator/principal approve or disapprove via a new Void Requests tab; admin-initiated voids auto-approve immediately (note still required). Voided payments remain in the ledger marked VOIDED and are excluded from totals, running balance, per-fee breakdown, and the Notice of Account.